### PR TITLE
Fix ColladaLoader loading <transparent> tag when <transparency> does not exist

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ## Ignition Common 3.X.X
 
+1. Fix ColladaLoader loading <transparent> tag when <transparency> does not exist
+    * [Pull request 68](https://github.com/ignitionrobotics/ign-common/pull/68)
+
 ## Ignition Common 3.5.0 (2020-04-09)
 
 1. Add interpolate\_x property to actor animations

--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -2610,6 +2610,15 @@ void ColladaLoaderPrivate::LoadTransparent(tinyxml2::XMLElement *_elem,
     double srcFactor = 0;
     double dstFactor = 0;
 
+    // If <transparency> tag exists, _mat->Transparency() should be set to
+    // that value already. Otherwise, use default value of 1.0 as per
+    // collada spec
+    double transparency = 1.0;
+    auto transparencyNode =
+        _elem->Parent()->FirstChildElement("transparency");
+    if (transparencyNode)
+      transparency = _mat->Transparency();
+
     // Calculate alpha based on opaque mode.
     // Equations are extracted from collada spec
     // Make sure to update the final transparency value
@@ -2624,8 +2633,8 @@ void ColladaLoaderPrivate::LoadTransparent(tinyxml2::XMLElement *_elem,
       // (1.0f - luminance(transparent.rgb) * transparency)
       // where fb corresponds to the framebuffer (existing pixel) and
       // mat corresponds to material before transparency (texel)
-      dstFactor = luminance * _mat->Transparency();
-      srcFactor = 1.0 - luminance * _mat->Transparency();
+      dstFactor = luminance * transparency;
+      srcFactor = 1.0 - luminance * transparency;
       _mat->SetTransparency(dstFactor);
     }
     else if (opaqueStr == "RGB_ONE")
@@ -2639,8 +2648,8 @@ void ColladaLoaderPrivate::LoadTransparent(tinyxml2::XMLElement *_elem,
       // mat.a * (luminance(transparent.rgb) * transparency)
       // where fb corresponds to the framebuffer (existing pixel) and
       // mat corresponds to material before transparency (texel)
-      dstFactor = 1.0 - luminance * _mat->Transparency();
-      srcFactor = luminance * _mat->Transparency();
+      dstFactor = 1.0 - luminance * transparency;
+      srcFactor = luminance * transparency;
       _mat->SetTransparency(dstFactor);
     }
     else if (opaqueStr == "A_ONE")
@@ -2649,8 +2658,8 @@ void ColladaLoaderPrivate::LoadTransparent(tinyxml2::XMLElement *_elem,
       // (transparent.a * transparency)
       // where fb corresponds to the framebuffer (existing pixel) and
       // mat corresponds to material before transparency (texel)
-      dstFactor = 1.0 - color.A() * _mat->Transparency();
-      srcFactor = color.A() * _mat->Transparency();
+      dstFactor = 1.0 - color.A() * transparency;
+      srcFactor = color.A() * transparency;
       _mat->SetTransparency(dstFactor);
     }
     else if (opaqueStr == "A_ZERO")
@@ -2659,8 +2668,8 @@ void ColladaLoaderPrivate::LoadTransparent(tinyxml2::XMLElement *_elem,
       // (1.0f - transparent.a * transparency)
       // where fb corresponds to the framebuffer (existing pixel) and
       // mat corresponds to material before transparency (texel)
-      dstFactor = color.A() * _mat->Transparency();
-      srcFactor = 1.0 - color.A() * _mat->Transparency();
+      dstFactor = color.A() * transparency;
+      srcFactor = 1.0 - color.A() * transparency;
       _mat->SetTransparency(dstFactor);
     }
 

--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -154,6 +154,31 @@ TEST_F(ColladaLoader, Material)
   mat->BlendFactors(srcFactor, dstFactor);
   EXPECT_DOUBLE_EQ(1.0, srcFactor);
   EXPECT_DOUBLE_EQ(0.0, dstFactor);
+
+  common::Mesh *meshOpaque = loader.Load(
+      std::string(PROJECT_SOURCE_PATH) + "/test/data/box_opaque.dae");
+  ASSERT_TRUE(meshOpaque);
+
+  EXPECT_EQ(meshOpaque->MaterialCount(), 1u);
+
+  common::MaterialPtr matOpaque = meshOpaque->MaterialByIndex(0u);
+  ASSERT_TRUE(matOpaque != nullptr);
+
+  // Make sure we read the specular value
+  EXPECT_EQ(math::Color(0.0, 0.0, 0.0, 1.0), matOpaque->Ambient());
+  EXPECT_EQ(math::Color(0.64f, 0.64f, 0.64f, 1.0f), matOpaque->Diffuse());
+  EXPECT_EQ(math::Color(0.5, 0.5, 0.5, 1.0), matOpaque->Specular());
+  EXPECT_EQ(math::Color(0.0, 0.0, 0.0, 1.0), matOpaque->Emissive());
+  EXPECT_DOUBLE_EQ(50.0, matOpaque->Shininess());
+  // transparent: opaque="A_ONE", color=[1 1 1 1]
+  // transparency: not specified, defaults to 1.0
+  // resulting transparency value = (1 - color.a * transparency)
+  EXPECT_DOUBLE_EQ(0.0, matOpaque->Transparency());
+  srcFactor = -1;
+  dstFactor = -1;
+  matOpaque->BlendFactors(srcFactor, dstFactor);
+  EXPECT_DOUBLE_EQ(1.0, srcFactor);
+  EXPECT_DOUBLE_EQ(0.0, dstFactor);
 }
 
 /////////////////////////////////////////////////

--- a/test/data/box_opaque.dae
+++ b/test/data/box_opaque.dae
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="utf-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <unit name="meter" meter="1"/>
+    <up_axis>Z_UP</up_axis>
+  </asset>
+  <library_effects>
+    <effect id="Material-effect">
+      <profile_COMMON>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color sid="emission">0 0 0 1</color>
+            </emission>
+            <ambient>
+              <color sid="ambient">0 0 0 1</color>
+            </ambient>
+            <diffuse>
+              <color sid="diffuse">0.64 0.64 0.64 1</color>
+            </diffuse>
+            <specular>
+              <color sid="specular">0.5 0.5 0.5 1</color>
+            </specular>
+            <shininess>
+              <float sid="shininess">50</float>
+            </shininess>
+            <transparent opaque="A_ONE">
+              <color>1 1 1 1</color>
+            </transparent>
+            <index_of_refraction>
+              <float sid="index_of_refraction">1</float>
+            </index_of_refraction>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_materials>
+    <material id="Material-material" name="Material-material">
+      <instance_effect url="#Material-effect"/>
+    </material>
+  </library_materials>
+  <library_geometries>
+    <geometry id="Cube-mesh" name="Cube">
+      <mesh>
+        <source id="Cube-mesh-positions">
+          <float_array id="Cube-mesh-positions-array" count="24">1 1 -1 1 -1 -1 -1 -0.9999998 -1 -0.9999997 1 -1 1 0.9999995 1 0.9999994 -1.000001 1 -1 -0.9999997 1 -1 1 1</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-positions-array" count="8" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="Cube-mesh-normals">
+          <float_array id="Cube-mesh-normals-array" count="18">0 0 -1 0 0 1 1 -2.83122e-7 0 -2.83122e-7 -1 0 -1 2.23517e-7 -1.3411e-7 2.38419e-7 1 2.08616e-7</float_array>
+          <technique_common>
+            <accessor source="#Cube-mesh-normals-array" count="6" stride="3">
+              <param name="X" type="float"/>
+              <param name="Y" type="float"/>
+              <param name="Z" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="Cube-mesh-vertices">
+          <input semantic="POSITION" source="#Cube-mesh-positions"/>
+        </vertices>
+        <polylist material="Material-material" count="6">
+          <input semantic="VERTEX" source="#Cube-mesh-vertices" offset="0"/>
+          <input semantic="NORMAL" source="#Cube-mesh-normals" offset="1"/>
+          <vcount>4 4 4 4 4 4 </vcount>
+          <p>0 0 1 0 2 0 3 0 4 1 7 1 6 1 5 1 0 2 4 2 5 2 1 2 1 3 5 3 6 3 2 3 2 4 6 4 7 4 3 4 4 5 0 5 3 5 7 5</p>
+        </polylist>
+      </mesh>
+      <extra><technique profile="MAYA"><double_sided>1</double_sided></technique></extra>
+    </geometry>
+  </library_geometries>
+  <library_visual_scenes>
+    <visual_scene id="Scene" name="Scene">
+      <node id="Cube" name="Cube" type="NODE">
+        <instance_geometry url="#Cube-mesh">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="Material-material" target="#Material-material"/>
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#Scene"/>
+  </scene>
+</COLLADA>


### PR DESCRIPTION
When loading `<transparent>` tag in our current implementation, we use a transparency value of 0.0 if `<transparency>` does not tag exist. But according to collada 1.5 spec chapter 7-6, page 250:

```
If <transparency> does not exist then it has no effect on the equation’s result. This is equivalent
to a factor that is 1.0: 
```

This causes some meshes to be transparent, see  ignitionrobotics/ign-rendering#89. This PR fixes the default <transparency> value used in calculation.


Signed-off-by: Ian Chen <ichen@osrfoundation.org>