### PR TITLE
Remove unused included headers

### DIFF
--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -15,10 +15,6 @@
  *
 */
 #include <stdio.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
 
 #include <mutex>
 

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -15,9 +15,7 @@
  *
 */
 
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 
 #ifdef __linux__
 #include <sys/sendfile.h>

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -14,9 +14,6 @@
  * limitations under the License.
  *
 */
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
 
 #ifdef __linux__
 #include <sys/sendfile.h>


### PR DESCRIPTION
I had some failures on Windows related to these headers, but it turns  out that most of them are unused and probably they come from some old copy&paste, so they can be simply removed. 