### PR TITLE
Fixed the AudioDecoder class

### DIFF
--- a/av/include/ignition/common/AudioDecoder.hh
+++ b/av/include/ignition/common/AudioDecoder.hh
@@ -60,6 +60,7 @@ namespace ignition
 
       /// \brief Get the sample rate from the latest decoded file.
       /// \return Integer sample rate, such as 44100.
+      /// If no file is decoded, -1 is returned.
       public: int SampleRate();
 
       /// \brief Free audio object, close files, streams.

--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -172,7 +172,10 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
 /////////////////////////////////////////////////
 int AudioDecoder::SampleRate()
 {
-  return this->data->codecCtx->sample_rate;
+  if (this->data->codecCtx)
+    return this->data->codecCtx->sample_rate;
+
+  return -1;
 }
 
 /////////////////////////////////////////////////

--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -59,7 +59,7 @@ TEST(AudioDecoder, DataBuffer)
 {
   common::AudioDecoder audio;
 
-  std::string path = PROJECT_SOURCE_PATH;
+  std::string path = TEST_PATH;
   path += "/data/cheer.wav";
   EXPECT_TRUE(audio.SetFile(path));
 
@@ -110,8 +110,8 @@ TEST(AudioDecoder, CheerFile)
     path = TEST_PATH;
     path += "/data/cheer.wav";
     EXPECT_TRUE(audio.SetFile(path));
-    EXPECT_EQ(audio.GetFile(), path);
-    EXPECT_EQ(audio.GetSampleRate(), 48000);
+    EXPECT_EQ(audio.File(), path);
+    EXPECT_EQ(audio.SampleRate(), 48000);
 
     audio.Decode(&dataBuffer, &dataBufferSize);
     EXPECT_EQ(dataBufferSize, 5428692u);
@@ -122,8 +122,8 @@ TEST(AudioDecoder, CheerFile)
     path = TEST_PATH;
     path += "/data/cheer.ogg";
     EXPECT_TRUE(audio.SetFile(path));
-    EXPECT_EQ(audio.GetFile(), path);
-    EXPECT_EQ(audio.GetSampleRate(), 44100);
+    EXPECT_EQ(audio.File(), path);
+    EXPECT_EQ(audio.SampleRate(), 44100);
 
     audio.Decode(&dataBuffer, &dataBufferSize);
     // In Ubuntu trusty the buffer size double for ogg decoding.
@@ -137,11 +137,17 @@ TEST(AudioDecoder, CheerFile)
     path = TEST_PATH;
     path += "/data/cheer.mp3";
     EXPECT_TRUE(audio.SetFile(path));
-    EXPECT_EQ(audio.GetFile(), path);
-    EXPECT_EQ(audio.GetSampleRate(), 44100);
+    EXPECT_EQ(audio.File(), path);
+    EXPECT_EQ(audio.SampleRate(), 44100);
 
     audio.Decode(&dataBuffer, &dataBufferSize);
-    EXPECT_EQ(dataBufferSize, 4995072u);
+
+    // later versions of ffmpeg produces a different buffer size probably due to
+    // underlying changes in the decoder. The size of the first decoded frame
+    // is much smaller than all other frames.
+    EXPECT_TRUE(dataBufferSize == 4995072u ||
+                dataBufferSize == 4987612u ||
+                dataBufferSize == 4987612u * 2);
   }
 }
 

--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -30,6 +30,9 @@ TEST(AudioDecoder, FileNotSet)
   unsigned int dataBufferSize;
   uint8_t *dataBuffer = NULL;
   EXPECT_FALSE(audio.Decode(&dataBuffer, &dataBufferSize));
+
+  EXPECT_EQ(audio.File(), "");
+  EXPECT_EQ(audio.SampleRate(), -1);
 }
 
 /////////////////////////////////////////////////

--- a/av/src/CMakeLists.txt
+++ b/av/src/CMakeLists.txt
@@ -1,9 +1,5 @@
 ign_get_libsources_and_unittests(sources gtest_sources)
 
-# FIXME: This class does not currently work
-list(REMOVE_ITEM sources AudioDecoder.cc)
-list(REMOVE_ITEM gtest_sources AudioDecoder_TEST.cc)
-
 ign_add_component(av SOURCES ${sources} GET_TARGET_NAME av_target)
 
 target_link_libraries(${av_target}


### PR DESCRIPTION
I've updated the [unit tests](https://github.com/ignitionrobotics/ign-common/blob/audioDecoder_fix_adlarkin/av/src/AudioDecoder_TEST.cc) for the `AudioDecoder` class so that they compile and pass.

I also added a check in `AudioDecoder::SampleRate` to ensure that a null pointer is not de-referenced in case users call `AudioDecoder::SampleRate` before calling `AudioDecoder::SetFile`.

One question: In the case where users call `AudioDecoder::SampleRate` before calling `AudioDecoder::SetFile`, what should `AudioDecoder::SampleRate` return? I made `AudioDecoder::SampleRate` return `-1` in this case, because I figured that a negative sample rate implies that the decoder's current state is invalid. I anyone thinks there is a better value to return (for example, `0`), let me know, and I will update `AudioDecoder::SampleRate` accordingly.