### PR TITLE
Fix Profiler.md image link on ignition website

### DIFF
--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -115,7 +115,7 @@ colcon build --cmake-args -DENABLE_PROFILER=1
 
 If the profiler is run successfully, you should see output in a browser. Similar to this 
 
-![profiler viewer exmaple](imgs/profiler_tutorial_example.png)
+<img src="https://raw.githubusercontent.com/ignitionrobotics/ign-common/ign-common3/tutorials/imgs/profiler_tutorial_example.png">
 
 ### Troubleshoot the web viewer
 


### PR DESCRIPTION
Use html instead of markdown image link to render image on ignition website