### PR TITLE
Deprecated common:Time

### DIFF
--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -13,4 +13,4 @@ cmake ..
 make
 
 # return to the compilation place
-cd ../build
+cd ../../build

--- a/.github/ci-bionic/after_make.sh
+++ b/.github/ci-bionic/after_make.sh
@@ -11,3 +11,6 @@ mkdir build
 cd build
 cmake ..
 make
+
+# return to the compilation place
+cd ../build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ message(STATUS "\n\n-- ====== Finding Dependencies ======")
 
 #--------------------------------------
 # Find ignition-math
-ign_find_package(ignition-math6 REQUIRED_BY graphics events)
+ign_find_package(ignition-math6 REQUIRED_BY graphics events VERSION 6.6)
 set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/common/Time.hh
+++ b/include/ignition/common/Time.hh
@@ -76,7 +76,7 @@ namespace ignition
 
       /// \brief Get the wall time
       /// \return the current time
-      public: static const Time &SystemTime();
+      public: static const IGN_DEPRECATED(3) Time &SystemTime();
 
       /// \brief Set to sec and nsec
       /// \param[in] _sec Seconds
@@ -103,7 +103,7 @@ namespace ignition
       /// actual call to the system's sleep function.
       ///
       /// On Windows the return value is always common::Time::Zero.
-      public: static Time Sleep(const common::Time &_time);
+      public: static Time IGN_DEPRECATED(3) Sleep(const common::Time &_time);
 
       /// \brief Get the time as a string formatted as "DD hh:mm:ss.mmm", with
       /// the option to choose the start/end.

--- a/include/ignition/common/Time.hh
+++ b/include/ignition/common/Time.hh
@@ -52,31 +52,31 @@ namespace ignition
       };
 
       /// \brief Constructors
-      public: IGN_DEPRECATED(3) Time();
+      public: IGN_DEPRECATED(4) Time();
 
       /// \brief Copy constructor
       /// \param[in] time Time to copy
-      public: IGN_DEPRECATED(3) Time(const Time &_time);
+      public: IGN_DEPRECATED(4) Time(const Time &_time);
 
       /// \brief Constructor
       /// \param[in] _tv Time to initialize to
-      public: explicit IGN_DEPRECATED(3) Time(const struct timespec &_tv);
+      public: explicit IGN_DEPRECATED(4) Time(const struct timespec &_tv);
 
       /// \brief Constructor
       /// \param[in] _sec Seconds
       /// \param[in] _nsec Nanoseconds
-      public: IGN_DEPRECATED(3) Time(int32_t _sec, int32_t _nsec);
+      public: IGN_DEPRECATED(4) Time(int32_t _sec, int32_t _nsec);
 
       /// \brief Constuctor
       /// \param[in] _time Time in double format sec.nsec
-      public: explicit IGN_DEPRECATED(3) Time(double _time);
+      public: explicit IGN_DEPRECATED(4) Time(double _time);
 
       /// \brief Destructor
       public: virtual ~Time();
 
       /// \brief Get the wall time
       /// \return the current time
-      public: static const IGN_DEPRECATED(3) Time &SystemTime();
+      public: static const IGN_DEPRECATED(4) Time &SystemTime();
 
       /// \brief Set to sec and nsec
       /// \param[in] _sec Seconds
@@ -103,7 +103,7 @@ namespace ignition
       /// actual call to the system's sleep function.
       ///
       /// On Windows the return value is always common::Time::Zero.
-      public: static Time IGN_DEPRECATED(3) Sleep(const common::Time &_time);
+      public: static Time IGN_DEPRECATED(4) Sleep(const common::Time &_time);
 
       /// \brief Get the time as a string formatted as "DD hh:mm:ss.mmm", with
       /// the option to choose the start/end.

--- a/include/ignition/common/Time.hh
+++ b/include/ignition/common/Time.hh
@@ -52,24 +52,24 @@ namespace ignition
       };
 
       /// \brief Constructors
-      public: Time();
+      public: IGN_DEPRECATED(3) Time();
 
       /// \brief Copy constructor
       /// \param[in] time Time to copy
-      public: Time(const Time &_time);
+      public: IGN_DEPRECATED(3) Time(const Time &_time);
 
       /// \brief Constructor
       /// \param[in] _tv Time to initialize to
-      public: explicit Time(const struct timespec &_tv);
+      public: explicit IGN_DEPRECATED(3) Time(const struct timespec &_tv);
 
       /// \brief Constructor
       /// \param[in] _sec Seconds
       /// \param[in] _nsec Nanoseconds
-      public: Time(int32_t _sec, int32_t _nsec);
+      public: IGN_DEPRECATED(3) Time(int32_t _sec, int32_t _nsec);
 
       /// \brief Constuctor
       /// \param[in] _time Time in double format sec.nsec
-      public: explicit Time(double _time);
+      public: explicit IGN_DEPRECATED(3) Time(double _time);
 
       /// \brief Destructor
       public: virtual ~Time();

--- a/include/ignition/common/Timer.hh
+++ b/include/ignition/common/Timer.hh
@@ -46,7 +46,7 @@ namespace ignition
 
       /// \brief Get the elapsed time
       /// \return The time
-      public: Time Elapsed() const;
+      public: double Elapsed() const;
 
       /// \brief Stream operator friendly
       public: friend std::ostream &operator<<(std::ostream &out,
@@ -57,10 +57,10 @@ namespace ignition
               }
 
       /// \brief The time of the last call to Start
-      private: Time start;
+      private: std::chrono::steady_clock::time_point start;
 
       /// \brief The time when Stop was called.
-      private: Time stop;
+      private: std::chrono::steady_clock::time_point stop;
 
       /// \brief True if the timer is running.
       private: bool running;

--- a/include/ignition/common/Timer.hh
+++ b/include/ignition/common/Timer.hh
@@ -49,14 +49,14 @@ namespace ignition
       public: Time IGN_DEPRECATED(4) Elapsed() const;
 
       /// \brief Get the elapsed time
-      /// \return The time
-      public: double ElapsedTime() const;
+      /// \return The elapsed time
+      public: std::chrono::duration<double> ElapsedTime() const;
 
       /// \brief Stream operator friendly
       public: friend std::ostream &operator<<(std::ostream &out,
                                               const ignition::common::Timer &t)
               {
-                out << t.ElapsedTime();
+                out << t.ElapsedTime().count();
                 return out;
               }
 

--- a/include/ignition/common/Timer.hh
+++ b/include/ignition/common/Timer.hh
@@ -46,13 +46,17 @@ namespace ignition
 
       /// \brief Get the elapsed time
       /// \return The time
-      public: double Elapsed() const;
+      public: Time IGN_DEPRECATED(4) Elapsed() const;
+
+      /// \brief Get the elapsed time
+      /// \return The time
+      public: double ElapsedTime() const;
 
       /// \brief Stream operator friendly
       public: friend std::ostream &operator<<(std::ostream &out,
                                               const ignition::common::Timer &t)
               {
-                out << t.Elapsed();
+                out << t.ElapsedTime();
                 return out;
               }
 

--- a/include/ignition/common/Timer.hh
+++ b/include/ignition/common/Timer.hh
@@ -60,11 +60,13 @@ namespace ignition
                 return out;
               }
 
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief The time of the last call to Start
       private: std::chrono::steady_clock::time_point start;
 
       /// \brief The time when Stop was called.
       private: std::chrono::steady_clock::time_point stop;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
 
       /// \brief True if the timer is running.
       private: bool running;

--- a/include/ignition/common/WorkerPool.hh
+++ b/include/ignition/common/WorkerPool.hh
@@ -59,7 +59,15 @@ namespace ignition
       /// \returns true if all work was finished
       /// \remarks The return value can be false even when waiting forever if
       //           the WorkerPool is destructed before all work is completed
-      public: bool WaitForResults(const Time &_timeout = Time::Zero);
+      public: bool IGN_DEPRECATED(4) WaitForResults(const Time &_timeout);
+
+      /// \brief Waits until all work is done and threads are idle
+      /// \param[in] _timeout How long to wait, default to forever
+      /// \returns true if all work was finished
+      /// \remarks The return value can be false even when waiting forever if
+      //           the WorkerPool is destructed before all work is completed
+      public: bool WaitForResults(
+        const std::chrono::steady_clock::duration &_timeout = std::chrono::steady_clock::duration::zero());
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief private implementation pointer

--- a/include/ignition/common/WorkerPool.hh
+++ b/include/ignition/common/WorkerPool.hh
@@ -67,7 +67,8 @@ namespace ignition
       /// \remarks The return value can be false even when waiting forever if
       //           the WorkerPool is destructed before all work is completed
       public: bool WaitForResults(
-        const std::chrono::steady_clock::duration &_timeout = std::chrono::steady_clock::duration::zero());
+        const std::chrono::steady_clock::duration &_timeout =
+          std::chrono::steady_clock::duration::zero());
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
       /// \brief private implementation pointer

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,11 @@ ign_create_core_library(
 target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PRIVATE ${DL_TARGET})
 
+# This is required by the WorkerPool::WaitForResults(const Time &_timeout)
+# TODO(anyone): IGN_DEPRECATED(4). Remove this part when the method is removed
+target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
+  ${ignition-math${IGN_MATH_VER}_INCLUDE_DIRS})
+
 # Handle non-Windows configuration settings
 if(NOT WIN32)
 

--- a/src/Time.cc
+++ b/src/Time.cc
@@ -59,10 +59,25 @@
 using namespace ignition;
 using namespace common;
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 Time Time::wallTime;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 struct timespec Time::clockResolution;
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 const Time Time::Zero = common::Time(0, 0);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+
 const int32_t Time::nsInSec = 1000000000L;
 const int32_t Time::nsInMs = 1000000;
 
@@ -99,13 +114,19 @@ Time::Time(const Time &_time)
 : sec(_time.sec), nsec(_time.nsec)
 {
 }
-
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 /////////////////////////////////////////////////
 Time::Time(int32_t _sec, int32_t _nsec)
 : sec(_sec), nsec(_nsec)
 {
   this->Correct();
 }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 /////////////////////////////////////////////////
 Time::Time(double _time)
@@ -162,7 +183,14 @@ float Time::Float() const
 /////////////////////////////////////////////////
 Time Time::Sleep(const common::Time &_time)
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   if (_time >= clockResolution)
   {
@@ -174,7 +202,14 @@ Time Time::Sleep(const common::Time &_time)
     if (interval.tv_sec < 0)
     {
       ignerr << "Cannot sleep for negative time[" << _time << "]\n";
-      return result;
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
     // This assert conforms to the manpage for nanosleep
@@ -182,7 +217,14 @@ Time Time::Sleep(const common::Time &_time)
     {
       ignerr << "Nanoseconds of [" << interval.tv_nsec
             << "] must be in the range0 to 999999999.\n";
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
       return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
 #ifdef _WIN32
@@ -197,20 +239,41 @@ Time Time::Sleep(const common::Time &_time)
     if (timer == NULL)
     {
       ignerr << "Unable to create waitable timer. Sleep will be incorrect.\n";
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
       return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
     if (!SetWaitableTimer (timer, &sleepTime, 0, NULL, NULL, 0))
     {
       ignerr << "Unable to use waitable timer. Sleep will be incorrect.\n";
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
       return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
     if (WaitForSingleObject (timer, INFINITE) != WAIT_OBJECT_0)
     {
       ignerr <<
         "Unable to wait for a single object. Sleep will be incorrect.\n";
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
       return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
     }
 
     result.sec = 0;
@@ -241,7 +304,14 @@ Time Time::Sleep(const common::Time &_time)
     ignlog << "Sleep time is larger than clock resolution, skipping sleep\n";
   }
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -256,10 +326,24 @@ Time &Time::operator=(const Time &_time)
 /////////////////////////////////////////////////
 Time Time::operator+(const Time &_time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time t(this->sec + _time.sec, this->nsec + _time.nsec);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   t.Correct();
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return t;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -274,9 +358,16 @@ const Time &Time::operator+=(const Time &_time)
 /////////////////////////////////////////////////
 Time Time::operator-(const Time &_time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time t(this->sec - _time.sec, this->nsec - _time.nsec);
   t.Correct();
   return t;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -291,9 +382,16 @@ const Time &Time::operator-=(const Time &_time)
 /////////////////////////////////////////////////
 Time Time::operator*(const Time &_time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time t(this->sec * _time.sec, this->nsec * _time.nsec);
   t.Correct();
   return t;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -307,14 +405,26 @@ const Time &Time::operator*=(const Time &_time)
 /////////////////////////////////////////////////
 Time Time::operator/(const Time &_time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time result(*this);
-
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   if (_time.sec == 0 && _time.nsec == 0)
     ignerr << "Time divide by zero\n";
   else
     result.Set(this->Double() / _time.Double());
-
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return result;
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -333,7 +443,14 @@ bool Time::operator==(const Time &_time) const
 /////////////////////////////////////////////////
 bool Time::operator==(double _time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this == Time(_time);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -358,7 +475,14 @@ bool Time::operator<(const Time &_time) const
 /////////////////////////////////////////////////
 bool Time::operator<(double _time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this < Time(_time);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -370,7 +494,14 @@ bool Time::operator<=(const Time &_time) const
 /////////////////////////////////////////////////
 bool Time::operator<=(double _time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this <= Time(_time);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -382,7 +513,14 @@ bool Time::operator>(const Time &_time) const
 /////////////////////////////////////////////////
 bool Time::operator>(double _time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this > Time(_time);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -394,13 +532,27 @@ bool Time::operator>=(const Time &_time) const
 /////////////////////////////////////////////////
 bool Time::operator>=(double _time) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this >= Time(_time);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////
 bool Time::operator>=(const struct timespec &_tv) const
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   return *this >= Time(_tv);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 }
 
 /////////////////////////////////////////////////

--- a/src/Time_TEST.cc
+++ b/src/Time_TEST.cc
@@ -28,7 +28,7 @@ TEST(TimeTest, Time)
   common::Timer timer;
   timer.Start();
   IGN_SLEEP_MS(100);
-  EXPECT_TRUE(timer.Elapsed() > 0.1);
+  EXPECT_TRUE(timer.ElapsedTime() > 0.1);
 
 #ifndef _WIN32
 # pragma GCC diagnostic push

--- a/src/Time_TEST.cc
+++ b/src/Time_TEST.cc
@@ -30,6 +30,10 @@ TEST(TimeTest, Time)
   IGN_SLEEP_MS(100);
   EXPECT_TRUE(timer.Elapsed() > 0.1);
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   common::Time time;
   time = common::Time::SystemTime();
   EXPECT_TRUE(common::Time::SystemTime() - time < common::Time(0, 1000000));
@@ -58,6 +62,9 @@ TEST(TimeTest, Time)
   EXPECT_FALSE(time != common::Time(1, 1999));
 
   time += common::Time(0, 1);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   EXPECT_EQ(time, 1.0 + 2000*1e-9);
   EXPECT_FALSE(time != 1.0 + 2000*1e-9);
@@ -66,12 +73,26 @@ TEST(TimeTest, Time)
   EXPECT_TRUE(time >= 0.1);
 
   time.Set(1, 1000);
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   time = common::Time(1, 1000) * common::Time(2, 2);
   EXPECT_TRUE(time == common::Time(2, 2000));
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   time.Set(1, 1000);
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   time = common::Time(1, 1000) / common::Time(2, 2);
   EXPECT_TRUE(time == common::Time(0, 500000499));
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
   double sec = 1.0 + 1e-9;
   double msec = sec * 1e3;
@@ -86,6 +107,10 @@ TEST(TimeTest, Time)
 /////////////////////////////////////////////////
 TEST(TimeTest, String)
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   common::Time time(0);
 
   // Several combinations
@@ -173,16 +198,29 @@ TEST(TimeTest, String)
   EXPECT_EQ(time.FormattedString(common::Time::FormatOption::MINUTES,
                                  common::Time::FormatOption::MINUTES),
                                  "4320");
-
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   // Large time
   time = common::Time(1234567890, 123456789);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_EQ(time.FormattedString(), "14288 23:31:30.123");
 }
 
 /////////////////////////////////////////////////
 TEST(TimeTest, Double)
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   common::Time time(1, 900000000);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_DOUBLE_EQ(1.9, time.Double());
 
   time.Set(1, -900000000);
@@ -198,7 +236,14 @@ TEST(TimeTest, Double)
 /////////////////////////////////////////////////
 TEST(TimeTest, Float)
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   common::Time time(1, 900000000);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_FLOAT_EQ(1.9f, time.Float());
 
   time.Set(1, -900000000);
@@ -214,6 +259,10 @@ TEST(TimeTest, Float)
 /////////////////////////////////////////////////
 TEST(TimeTest, Sleep)
 {
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   common::Time sleepTime(1, 900000000);
   common::Time result = common::Time::Sleep(sleepTime);
 #ifdef _WIN32
@@ -221,6 +270,10 @@ TEST(TimeTest, Sleep)
   EXPECT_EQ(common::Time::Zero, result);
 #else
   EXPECT_EQ(sleepTime, result);
+#endif
+
+#ifndef _WIN32
+# pragma GCC diagnostic pop
 #endif
 }
 

--- a/src/Time_TEST.cc
+++ b/src/Time_TEST.cc
@@ -28,7 +28,7 @@ TEST(TimeTest, Time)
   common::Timer timer;
   timer.Start();
   IGN_SLEEP_MS(100);
-  EXPECT_TRUE(timer.ElapsedTime() > 0.1);
+  EXPECT_TRUE(timer.ElapsedTime().count() > 0.1);
 
 #ifndef _WIN32
 # pragma GCC diagnostic push

--- a/src/Time_TEST.cc
+++ b/src/Time_TEST.cc
@@ -28,7 +28,7 @@ TEST(TimeTest, Time)
   common::Timer timer;
   timer.Start();
   IGN_SLEEP_MS(100);
-  EXPECT_TRUE(timer.Elapsed() > common::Time(0, 100000000));
+  EXPECT_TRUE(timer.Elapsed() > 0.1);
 
   common::Time time;
   time = common::Time::SystemTime();

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -20,18 +20,11 @@
 using namespace ignition;
 using namespace common;
 
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
 //////////////////////////////////////////////////
 Timer::Timer()
   : running(false)
 {
 }
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
 
 //////////////////////////////////////////////////
 Timer::~Timer()

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -68,7 +68,8 @@ Time Timer::Elapsed() const
 # pragma GCC diagnostic pop
 #endif
   }
-  else{
+  else
+  {
     std::chrono::duration<double> diff = this->stop - this->start;
 #ifndef _WIN32
 # pragma GCC diagnostic push

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -83,18 +83,18 @@ Time Timer::Elapsed() const
 }
 
 //////////////////////////////////////////////////
-double Timer::ElapsedTime() const
+std::chrono::duration<double> Timer::ElapsedTime() const
 {
   if (this->running)
   {
     std::chrono::steady_clock::time_point currentTime;
     currentTime = std::chrono::steady_clock::now();
     std::chrono::duration<double> diff = currentTime - this->start;
-    return diff.count();
+    return diff;
   }
   else
   {
     std::chrono::duration<double> diff = this->stop - this->start;
-    return diff.count();
+    return diff;
   }
 }

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -20,11 +20,18 @@
 using namespace ignition;
 using namespace common;
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 //////////////////////////////////////////////////
 Timer::Timer()
   : running(false)
 {
 }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 //////////////////////////////////////////////////
 Timer::~Timer()
@@ -34,14 +41,14 @@ Timer::~Timer()
 //////////////////////////////////////////////////
 void Timer::Start()
 {
-  this->start = Time::SystemTime();
+  this->start = std::chrono::steady_clock::now();
   this->running = true;
 }
 
 //////////////////////////////////////////////////
 void Timer::Stop()
 {
-  this->stop = Time::SystemTime();
+  this->stop = std::chrono::steady_clock::now();
   this->running = false;
 }
 
@@ -52,15 +59,18 @@ bool Timer::Running() const
 }
 
 //////////////////////////////////////////////////
-Time Timer::Elapsed() const
+double Timer::Elapsed() const
 {
   if (this->running)
   {
-    Time currentTime;
-    currentTime = Time::SystemTime();
-
-    return currentTime - this->start;
+    std::chrono::steady_clock::time_point currentTime;
+    currentTime = std::chrono::steady_clock::now();
+    std::chrono::duration<double> diff = currentTime - this->start;
+    return diff.count();
   }
   else
-    return this->stop - this->start;
+  {
+    std::chrono::duration<double> diff = this->stop - this->start;
+    return diff.count();
+  }
 }

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -52,7 +52,37 @@ bool Timer::Running() const
 }
 
 //////////////////////////////////////////////////
-double Timer::Elapsed() const
+Time Timer::Elapsed() const
+{
+  if (this->running)
+  {
+    std::chrono::steady_clock::time_point currentTime;
+    currentTime = std::chrono::steady_clock::now();
+    std::chrono::duration<double> diff = currentTime - this->start;
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    return Time(diff.count());
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+  }
+  else{
+    std::chrono::duration<double> diff = this->stop - this->start;
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    return Time(diff.count());
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
+  }
+}
+
+//////////////////////////////////////////////////
+double Timer::ElapsedTime() const
 {
   if (this->running)
   {

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -51,36 +51,18 @@ bool Timer::Running() const
   return this->running;
 }
 
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
 //////////////////////////////////////////////////
 Time Timer::Elapsed() const
 {
-  if (this->running)
-  {
-    std::chrono::steady_clock::time_point currentTime;
-    currentTime = std::chrono::steady_clock::now();
-    std::chrono::duration<double> diff = currentTime - this->start;
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    return Time(diff.count());
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  }
-  else
-  {
-    std::chrono::duration<double> diff = this->stop - this->start;
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-    return Time(diff.count());
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  }
+  return common::Time(this->ElapsedTime().count());
 }
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
 
 //////////////////////////////////////////////////
 std::chrono::duration<double> Timer::ElapsedTime() const

--- a/src/WorkerPool.cc
+++ b/src/WorkerPool.cc
@@ -196,7 +196,8 @@ bool WorkerPool::WaitForResults(const Time &_timeout)
 }
 
 //////////////////////////////////////////////////
-bool WorkerPool::WaitForResults(const std::chrono::steady_clock::duration &_timeout)
+bool WorkerPool::WaitForResults(
+  const std::chrono::steady_clock::duration &_timeout)
 {
   bool signaled = true;
   std::unique_lock<std::mutex> queueLock(this->dataPtr->queueMtx);

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -92,15 +92,7 @@ TEST(WorkerPool, WaitWithTimeout)
       {
         workSentinel = 5;
       });
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  Time time(5);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  EXPECT_TRUE(pool.WaitForResults(time));
+  EXPECT_TRUE(pool.WaitForResults(std::chrono::seconds(5)));
   EXPECT_EQ(5, workSentinel);
 }
 
@@ -112,15 +104,7 @@ TEST(WorkerPool, WaitWithTimeoutThatTimesOut)
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
       });
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  Time time(0.0001);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  EXPECT_FALSE(pool.WaitForResults(time));
+  EXPECT_FALSE(pool.WaitForResults(std::chrono::nanoseconds(100000)));
 }
 
 //////////////////////////////////////////////////
@@ -147,15 +131,7 @@ TEST(WorkerPool, ThingsRunInParallel)
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ++sentinel;
       });
-#ifndef _WIN32
-# pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-  Time time(0.009);
-#ifndef _WIN32
-# pragma GCC diagnostic pop
-#endif
-  bool result = pool.WaitForResults(time);
+  bool result = pool.WaitForResults(std::chrono::milliseconds(9));
 #ifdef __linux__
   // the timing test is flaky on windows and mac
   EXPECT_TRUE(result);

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -92,7 +92,14 @@ TEST(WorkerPool, WaitWithTimeout)
       {
         workSentinel = 5;
       });
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time time(5);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_TRUE(pool.WaitForResults(time));
   EXPECT_EQ(5, workSentinel);
 }
@@ -105,7 +112,14 @@ TEST(WorkerPool, WaitWithTimeoutThatTimesOut)
       {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
       });
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time time(0.0001);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   EXPECT_FALSE(pool.WaitForResults(time));
 }
 
@@ -133,7 +147,14 @@ TEST(WorkerPool, ThingsRunInParallel)
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
         ++sentinel;
       });
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
   Time time(0.009);
+#ifndef _WIN32
+# pragma GCC diagnostic pop
+#endif
   bool result = pool.WaitForResults(time);
 #ifdef __linux__
   // the timing test is flaky on windows and mac


### PR DESCRIPTION
This PR is part of this issue https://github.com/ignitionrobotics/ign-common/issues/61. The idea it's to deprecate the class `common::Time` in favor of `std::chrono`.

This two functions convert from `time_point` to seconds and nanoseconds and viceversa.

Signed-off-by: ahcorde <ahcorde@gmail.com>