### PR TITLE
Small Remotery tutorials fixes

### DIFF
--- a/profiler/src/RemoteryProfilerImpl.cc
+++ b/profiler/src/RemoteryProfilerImpl.cc
@@ -184,7 +184,7 @@ RemoteryProfilerImpl::RemoteryProfilerImpl()
     static_cast<RemoteryProfilerImpl *>(_context)->HandleInput(_text);
   };
 
-  igndbg << "Staring ign-common profiler impl: Remotery" <<
+  igndbg << "Starting ign-common profiler impl: Remotery" <<
     " (port: " << this->settings->port << ")" << std::endl;
   rmtError error;
   error = rmt_CreateGlobalInstance(&this->rmt);

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -113,6 +113,11 @@ When compiling with ``colcon``:
 colcon build --cmake-args -DENABLE_PROFILER=1
 ```
 
+Run your Ignition library then open the profiler browser using:
+```
+ign_remotery_vis
+```
+
 If the profiler is run successfully, you should see output in a browser. Similar to this 
 
 <img src="https://raw.githubusercontent.com/ignitionrobotics/ign-common/ign-common3/tutorials/imgs/profiler_tutorial_example.png">
@@ -120,13 +125,13 @@ If the profiler is run successfully, you should see output in a browser. Similar
 ### Troubleshoot the web viewer
 
 If you see ``connection error``, there are a couple of things to double check
-1. Was the profiler enabled when the project you're trying to run was compiled? Note that this isn't the case if you installed Ignition libraries from binaries, for example. You need to compile the project from source with the ENABLE_PROFILER variable set.
-2. Are you using the correct port number in the upper left corner ``Connection Addresss: ws://127.0.0.1:1500/rmt``? Run ``ign gazebo -v 4`` to show the port number in use. The port number will be printed out if the profiler is enabled. 
+1. Was the profiler enabled when the project you're trying to run was compiled? Note that this isn't the case if you installed Ignition libraries from binaries, for example. You need to compile the project from source with the `ENABLE_PROFILER` variable set.
+2. Are you using the correct port number in the upper left corner ``Connection Addresss: ws://127.0.0.1:1500/rmt``? Running ``ign gazebo -v 4`` will show the port number in use near the top of the outputted text. The port number will be printed out if the profiler is enabled. 
 
     ```{.sh}
-    [Dbg] [RemoteryProfilerImpl.cc:187] Staring ign-common profiler impl: Remotery (port: 1500)
+    [Dbg] [RemoteryProfilerImpl.cc:187] Starting ign-common profiler impl: Remotery (port: 1500)
     ```
-3. Are you running the program in a separate terminal? Profiler only establishes connection if there is a program runing and being actively profiled.
+3. Are you running the program in a separate terminal? The profiler only establishes connection if there is a program running and being actively profiled.
 
 4. If you want to use a different port, configure the environment variable `RMT_PORT` by running the following in terminal, and update the web viewer port in your browser accordingly (see 2 above)
     ```{.sh}


### PR DESCRIPTION
Just some small fixes that I came across while going through this tutorial.  I also added a line more explicitly indicated to run `ign_remotery_vis` for Ignition libraries as it wasn't immediately clear to me how to open the browser window when profiling Ignition libraries

Signed-off-by: John Shepherd <john@openrobotics.org>