### PR TITLE
Fix trajectory info memory leak

### DIFF
--- a/graphics/src/Animation.cc
+++ b/graphics/src/Animation.cc
@@ -408,6 +408,7 @@ TrajectoryInfo::TrajectoryInfo(TrajectoryInfo &&_trajInfo) noexcept
 /////////////////////////////////////////////////
 TrajectoryInfo::~TrajectoryInfo()
 {
+  delete this->dataPtr;
 }
 
 //////////////////////////////////////////////////


### PR DESCRIPTION
Simple fix but took awhile to find and I think deserves some explanation as well as some tools I used that can be used in the future for memory profiling (possibly this part deserves its own tutorial or guide).

It was discovered that there was a significant memory leak in any ign-gazebo examples involving actors.  I used a project called [mem-usage-ui](https://github.com/parikls/mem_usage_ui) which was very simple yet effective in being able to visually confirm the existence of memory leaks.  The output from the actor example that was experiencing serious leakage is as follows: 
![Citadel-actor-population-no-delete](https://user-images.githubusercontent.com/8881852/92835143-baea1f80-f38f-11ea-9d62-91c709f57e74.png)

It can be seen that the memory leakage grew by about 100Mb in just one minute, if left for 15-20 minutes, this could crash the computer.  Using [heaptrack](https://github.com/KDE/heaptrack) or `valgrind` didn't quite prove effective given it monitors the ruby executable, outputting little to no helpful information.  For this reason, I'd recommend we get a standalone custom gui example out, similar to [custom_server](https://github.com/ignitionrobotics/ign-gazebo/tree/master/examples/standalone/custom_server) as this would allow `valgrind` to do its job.  I did, however, find that [memleax](https://github.com/WuBingzheng/memleax) was quite useful in pinpointing memory leaks, the output is a bit complicated to discern and there are false positives, but it proved very helpful in pointing me right to the culprit function that was leaking (in this case, [ActorMeshAnimationAt(...)](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo3/src/rendering/SceneManager.cc#L883)).

After further investigation, I found that [line 894 of SceneManager.cc](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo3/src/rendering/SceneManager.cc#L894) `auto trajs = this->dataPtr->actorTrajectories[_id];` was the problem line that was spawning new `TrajectoryInfo`'s, invoking [this constructor](https://github.com/ignitionrobotics/ign-common/blob/ign-common3/graphics/src/Animation.cc#L426-L430) for every currently existing `TrajectoryInfo` in the `this->dataPtr->actorTrajectories[_id]` vector, I suppose when assigning that vector to a new variable, the (deep) copy operation is made and that vector is duplicated, resulting in the original vector remaining as the value of that `this->dataPtr->actorTrajectories` map and a new copy vector set to `trajs`.

So adding a simple deletion of `this->dataPtr` to the destructor of `TrajectoryInfo` fixed up the memory leak, which can be visually confirmed in the following graph
![Citadel-actors-population-delete](https://user-images.githubusercontent.com/8881852/92837648-b2dfaf00-f392-11ea-9c5a-5d270fa2b202.png)

So, not perfect, there appears to be another smaller leak somewhere, but ~10Mb / minute is much better than the original.  I'll continue to look for the remaining leaks.

Signed-off-by: John Shepherd <john@openrobotics.org>