### PR TITLE
Remove invalid URI warning

### DIFF
--- a/src/URI.cc
+++ b/src/URI.cc
@@ -576,8 +576,7 @@ URI::URI()
 URI::URI(const std::string &_str)
   : URI()
 {
-  if (!this->Parse(_str))
-    ignwarn << "Unable to parse URI [" << _str << "]. Ignoring." << std::endl;
+  this->Parse(_str);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
Ever since the addition of fuel world support, we've started to check the passed in file string.  In order to check for a valid URI link, we've been using `common::URI` ([here](https://github.com/ignitionrobotics/ign-gazebo/blob/master/src/Server.cc#L155)) which prints a warning message if the URI is not a correctly formatted URI.  Since we are using this class to check for a valid URI, the warning message removed in this PR prints for every non-valid URI file which is quite misleading.

Signed-off-by: John Shepherd <john@openrobotics.org>