### PR TITLE
[ign-common3] Improve fork experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Ubuntu CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   bionic-ci:
@@ -23,5 +23,3 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
-        with:
-          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr-collection-labeler.yml
+++ b/.github/workflows/pr-collection-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Collection Labeler
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   pr_collection_labeler:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,7 +1,7 @@
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 name: Ticket opened
 jobs:


### PR DESCRIPTION
Our GitHub actions haven't been running correctly for forks. This should fix all of them:

## CI

CI only on `push` means that PRs from forks aren't tested. Adding `pull_request` fixes forks, with the downside of triggering duplicated jobs for PRs coming from branches in this repo.

Also removed the codecov token for the Focal builds because we only need to upload coverage reports once, and this causes failures sometimes.

## Labeler

Resolves https://github.com/ignition-tooling/pr-collection-labeler/issues/4.

Uses the new [pull_request_target event](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).

Tested here: https://github.com/ignitionrobotics/testing/pull/14

## Triage

Like above, uses the new [pull_request_target event](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/).

Tested here: https://github.com/ignitionrobotics/testing/pull/15
