### PR TITLE
Fix video encoder timing

### DIFF
--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,6 +58,15 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
+      /// \brief Convenience type alias for duration
+      /// where 1000000 is the same as AV_TIME_BASE fractional seconds
+      public:
+        using Length = std::chrono::duration<int64_t, std::ratio<1, 1000000>>;
+
+      /// \brief Get the duration of the video
+      /// \return the duration
+      public: Length Duration() const;
+
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored
       /// \return  false on error

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -289,3 +289,9 @@ int Video::Height() const
 {
   return this->dataPtr->codecCtx->height;
 }
+
+/////////////////////////////////////////////////
+Video::Length Video::Duration() const
+{
+  return Video::Length(this->dataPtr->formatCtx->duration);
+}

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -128,7 +128,8 @@ bool VideoEncoder::Start(const std::string &_format,
   // This will be true if Stop has been called, but not reset. We will reset
   // automatically to prevent any errors.
   if (this->dataPtr->formatCtx || this->dataPtr->avInFrame ||
-      this->dataPtr->avOutFrame || this->dataPtr->swsCtx)
+      this->dataPtr->avOutFrame || this->dataPtr->swsCtx ||
+      this->dataPtr->frameCount > 0u)
   {
     this->Reset();
   }

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -510,7 +510,8 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
 
   // Skip frames that arrive faster than the video's fps
   double period = 1.0/this->dataPtr->fps;
-  if (dt < std::chrono::duration<double>(period))
+  if (this->dataPtr->frameCount > 0u &&
+      dt < std::chrono::duration<double>(period))
     return false;
 
   if (this->dataPtr->frameCount == 0u)
@@ -777,4 +778,6 @@ void VideoEncoder::Reset()
   this->dataPtr->bitRate = VIDEO_ENCODER_BITRATE_DEFAULT;
   this->dataPtr->fps = VIDEO_ENCODER_FPS_DEFAULT;
   this->dataPtr->format = VIDEO_ENCODER_FORMAT_DEFAULT;
+  this->dataPtr->timePrev = std::chrono::steady_clock::time_point();
+  this->dataPtr->timeStart = std::chrono::steady_clock::time_point();
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -8,7 +8,8 @@ list(REMOVE_ITEM tests mesh.cc)
 
 ign_build_tests(
   TYPE INTEGRATION
-  SOURCES ${tests})
+  SOURCES ${tests}
+  LIB_DEPS ${PROJECT_LIBRARY_TARGET_NAME}-av)
 
 if(TARGET INTEGRATION_plugin)
   # We add this dependency to make sure that DummyPlugins gets generated

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -6,14 +6,22 @@ ign_get_sources(tests)
 # FIXME the mesh test does not work
 list(REMOVE_ITEM tests mesh.cc)
 
+if (${SKIP_av})
+  list(REMOVE_ITEM tests encoder_timing.cc)
+endif()
+
 ign_build_tests(
   TYPE INTEGRATION
   SOURCES ${tests}
-  LIB_DEPS ${PROJECT_LIBRARY_TARGET_NAME}-av)
+)
 
 if(TARGET INTEGRATION_plugin)
   # We add this dependency to make sure that DummyPlugins gets generated
   # before INTEGRATION_plugin so that its auto-generated header is available.
   # We do not want to link INTEGRATION_plugin to the DummyPlugins library.
   add_dependencies(INTEGRATION_plugin IGNDummyPlugins)
+endif()
+
+if(TARGET INTEGRATION_encoder_timing)
+  target_link_libraries(INTEGRATION_encoder_timing ${PROJECT_LIBRARY_TARGET_NAME}-av)
 endif()

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+#include <array>
+#include "ignition/common/VideoEncoder.hh"
+#include "ignition/common/Video.hh"
+#include "test_config.h"
+#include "test/util.hh"
+
+using namespace ignition;
+using namespace common;
+
+const unsigned int kSize = 10;
+const std::array<unsigned char, kSize*kSize> kFrame = {};
+
+// set to 720ms because video duration missing additional 18 frames
+//    which may be due to how video encoding works
+const std::chrono::milliseconds kTol(720);
+
+void durationTest(VideoEncoder &_vidEncoder, Video &_video,
+                  const int &_fps, const int &_seconds)
+{
+  _vidEncoder.Start("mp4", "", kSize, kSize, _fps, 0);
+
+  int frameCount = 0;
+  while (frameCount != _fps*_seconds)
+  {
+    if (_vidEncoder.AddFrame(kFrame.data(), kSize, kSize))
+      ++frameCount;
+  }
+
+  _vidEncoder.Stop();
+  _video.Load(common::joinPaths(common::cwd(), "/TMP_RECORDING.mp4"));
+
+  EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(
+              _video.Duration()).count(),
+              _seconds*1000,
+              kTol.count());
+}
+
+TEST(EncoderTimingTest, Duration)
+{
+  VideoEncoder vidEncoder;
+  Video video;
+
+  durationTest(vidEncoder, video, 50, 1);
+  durationTest(vidEncoder, video, 30, 2);
+  durationTest(vidEncoder, video, 25, 5);
+}


### PR DESCRIPTION
The video encoder timing is incorrect when the source that's being encoded runs at a dynamic / slower FPS than the default video encoding rate (25 FPS). In ignition gazebo, this often happens when recording simulations with fluctuating GUI FPS (e.g. due to objects loading and unloading or complex scene), resulting in videos that have a shorter duration than expected.

More info:
The main cause of the problem is from setting the frame number associated with an input frame to be encoded. When a new frame arrives and is ready to be encoded, the frame is appended to the video by always setting it's frame number to frame count + 1. However, if the frame arrives late, e.g. several seconds late, the frame number should not just be incremented by 1 but a larger number (depending on how late the frame arrives and the video FPS). The timing issue is fixed in this PR by computing the absolute frame number based on the timestamp of the input frame and the specified FPS.

Signed-off-by: Ian Chen <ichen@osrfoundation.org>