### PR TITLE
Add Console example

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,9 @@ find_package(ignition-common3 QUIET REQUIRED COMPONENTS events profiler)
 add_executable(assert_example assert_example.cc)
 target_link_libraries(assert_example ignition-common3::core)
 
+add_executable(console_example console.cc)
+target_link_libraries(console_example ignition-common3::core)
+
 add_executable(events_example events.cc)
 target_link_libraries(events_example ignition-common3::events)
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples
+
+These examples demonstrate various Ignition Common features.
+
+## Build
+
+After installing Ignition Common, from source or from binaries, build with:
+
+```
+git clone https://github.com/ignitionrobotics/ign-common/
+cd ign-common/examples
+mkdir build
+cd build
+cmake ..
+make
+```
+
+## Run
+
+One execuable is created inside the `build` folder for each example.
+
+You can run each executable from the build folder with `./executablename`. For example:
+
+`./events_example`
+

--- a/examples/console.cc
+++ b/examples/console.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <ignition/common.hh>
+
+int main(int argc, char **argv)
+{
+  // Default verbosity is 1, only error messages show
+  igndbg << "This is a debug message" << std::endl;
+  ignmsg << "This is an informational message" << std::endl;
+  ignwarn << "This is a warning" << std::endl;
+  ignerr << "This is an error" << std::endl;
+
+  // Change verbosity to level 4, all messages show
+  ignition::common::Console::SetVerbosity(4);
+  igndbg << "This is a debug message" << std::endl;
+  ignmsg << "This is an informational message" << std::endl;
+  ignwarn << "This is a warning" << std::endl;
+  ignerr << "This is an error" << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
The motivation was to test this issue: https://github.com/ignitionrobotics/ign-common/issues/6

Also added a README to all examples.

I think we should consider putting each example into its own directory so they're self-contained. A new user might not necessarily know how to split them, especially as they get more complex.