### PR TITLE
[ign-common3] Miscellaneous Cleanups

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,17 +1,18 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the ignition-common library
-find_package(ignition-common3 QUIET REQUIRED COMPONENTS events profiler)
+set(IGN_COMMON_VER 3)
+find_package(ignition-common${IGN_COMMON_VER} QUIET REQUIRED COMPONENTS events profiler)
 
 add_executable(assert_example assert_example.cc)
-target_link_libraries(assert_example ignition-common3::core)
+target_link_libraries(assert_example ignition-common${IGN_COMMON_VER}::core)
 
 add_executable(console_example console.cc)
-target_link_libraries(console_example ignition-common3::core)
+target_link_libraries(console_example ignition-common${IGN_COMMON_VER}::core)
 
 add_executable(events_example events.cc)
-target_link_libraries(events_example ignition-common3::events)
+target_link_libraries(events_example ignition-common${IGN_COMMON_VER}::events)
 
 add_executable(profiler_example profiler.cc)
-target_link_libraries(profiler_example ignition-common3::profiler)
+target_link_libraries(profiler_example ignition-common${IGN_COMMON_VER}::profiler)
 target_compile_definitions(profiler_example PUBLIC "IGN_PROFILER_ENABLE=1")

--- a/include/ignition/common/StringUtils.hh
+++ b/include/ignition/common/StringUtils.hh
@@ -33,6 +33,30 @@ namespace ignition
     std::vector<std::string> IGNITION_COMMON_VISIBLE Split(
         const std::string &_orig, char _delim);
 
+    /// \brief Join a sequence of strings with a delimiter
+    ///
+    /// Note that this will skip any empty entries in the vector,
+    /// and will also not prepend or append the delimiter to the
+    /// final output string
+    ///
+    /// \param[in] _orig The input sequence of strings
+    /// \param[in] _delim a string delimiter to join the string with
+    /// \returns a single string composed of strings joined with the delimiter
+    std::string IGNITION_COMMON_VISIBLE Join(
+        const std::vector<std::string> &_orig, const std::string &_delim);
+
+    /// \brief Join a sequence of strings with a delimiter
+    ///
+    /// Note that this will skip any empty entries in the vector,
+    /// and will also not prepend or append the delimiter to the
+    /// final output string
+    ///
+    /// \param[in] _orig The input sequence of strings
+    /// \param[in] _delim a character to join the string with
+    /// \returns a single string composed of strings joined with the delimiter
+    std::string IGNITION_COMMON_VISIBLE Join(
+        const std::vector<std::string> &_orig, char _delim);
+
     /// \brief return true if string starts with another string
     /// \param[in] _s1 the string to check
     /// \param[in] _s2 the possible prefix

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -25,6 +25,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "ignition/common/Util.hh"
+
 // The symlink tests should always work on UNIX systems
 #define BUILD_SYMLINK_TESTS
 
@@ -32,12 +34,8 @@
 bool create_and_switch_to_temp_dir(std::string &_new_temp_path)
 {
   std::string tmppath;
-  const char *tmp = getenv("TMPDIR");
-  if (tmp)
-  {
-    tmppath = std::string(tmp);
-  }
-  else
+
+  if (!ignition::common::env("TMPDIR", tmppath))
   {
     tmppath = std::string("/tmp");
   }

--- a/src/StringUtils.cc
+++ b/src/StringUtils.cc
@@ -39,6 +39,30 @@ namespace ignition
     }
 
     //////////////////////////////////////////////////
+    std::string Join(const std::vector<std::string> &_orig,
+                     const std::string &_delim)
+    {
+      std::string ret = "";
+      for (size_t ii = 0; ii < _orig.size(); ++ii)
+      {
+        if (_orig[ii].empty())
+          continue;
+
+        ret += _orig[ii];
+        if (ii < _orig.size() - 1)
+        {
+          ret += _delim;
+        }
+      }
+      return ret;
+    }
+    //////////////////////////////////////////////////
+    std::string Join(const std::vector<std::string> &_orig, char _delim)
+    {
+      return Join(_orig, std::string(1, _delim));
+    }
+
+    //////////////////////////////////////////////////
     bool StartsWith(const std::string &_s1, const std::string &_s2)
     {
       if (_s1.size() >= _s2.size())

--- a/src/StringUtils_TEST.cc
+++ b/src/StringUtils_TEST.cc
@@ -71,6 +71,59 @@ TEST(StringUtils, SplitOneDelimiterAtEnd)
 }
 
 /////////////////////////////////////////////////
+TEST(Join, Simple)
+{
+  {
+    std::string delim = " ";
+    auto pieces = std::vector<std::string>{"Hello", "World"};
+    auto joined = common::Join(pieces, delim);
+    EXPECT_EQ("Hello World", joined);
+  }
+
+  {
+    std::string delim = "x";
+    auto pieces = std::vector<std::string>{"Hello", "World"};
+    auto joined = common::Join(pieces, delim);
+    EXPECT_EQ("HelloxWorld", joined);
+  }
+
+  {
+    std::string delim = "x";
+    auto pieces = std::vector<std::string>{
+      "foo", "bar", "baz", "bing"};
+    auto joined = common::Join(pieces, delim);
+    EXPECT_EQ("fooxbarxbazxbing", joined);
+  }
+}
+
+/////////////////////////////////////////////////
+TEST(Join, EmptyDelim)
+{
+  std::string delim = "";
+  auto pieces = std::vector<std::string>{"Hello", "World"};
+  auto joined = common::Join(pieces, delim);
+  EXPECT_EQ("HelloWorld", joined);
+}
+
+/////////////////////////////////////////////////
+TEST(Join, EmptyPart)
+{
+  std::string delim = " ";
+  auto pieces = std::vector<std::string>{"Hello", "", "World"};
+  auto joined = common::Join(pieces, delim);
+  EXPECT_EQ("Hello World", joined);
+}
+
+/////////////////////////////////////////////////
+TEST(Join, EmptyParts)
+{
+  std::string delim = "x";
+  auto pieces = std::vector<std::string>{};
+  auto joined = common::Join(pieces, delim);
+  EXPECT_EQ("", joined);
+}
+
+/////////////////////////////////////////////////
 TEST(StartsWith, NotInString)
 {
   std::string big = "Hello World!";


### PR DESCRIPTION
A few things that I found when doing the forward port

1. Use variables in the examples `CMakeLists.txt` file to keep things from breaking across ports
2. Add a string "Join" function for convenience.
3. Replace all `getenv`, `setenv`, `putenv`, `unsetenv` with Ignition functionality.