### PR TITLE
Video encoder timing test

### DIFF
--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,6 +58,9 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
+      // TODO: doc
+      public: int64_t Duration() const;
+
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored
       /// \return  false on error

--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,9 +58,14 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
-      // \brief Get the duration of the video where 1000000 is AV_TIME_BASE fractional seconds
-      // \return the duration
-      public: std::chrono::duration<int64_t, std::ratio<1, 1000000>> Duration() const;
+      /// \brief Convenience type alias for duration
+      /// where 1000000 is the same as AV_TIME_BASE fractional seconds
+      private:
+        using Length = std::chrono::duration<int64_t, std::ratio<1, 1000000>>;
+
+      /// \brief Get the duration of the video
+      /// \return the duration
+      public: Length Duration() const;
 
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored

--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,8 +58,9 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
-      // TODO: doc
-      public: int64_t Duration() const;
+      // \brief Get the duration of the video where 1000000 is AV_TIME_BASE fractional seconds
+      // \return the duration
+      public: std::chrono::duration<int64_t, std::ratio<1, 1000000>> Duration() const;
 
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored

--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,14 +58,10 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
-      /// \brief Convenience type alias for duration
-      /// where 1000000 is the same as AV_TIME_BASE fractional seconds
-      private:
-        using Length = std::chrono::duration<int64_t, std::ratio<1, 1000000>>;
-
       /// \brief Get the duration of the video
       /// \return the duration
-      public: Length Duration() const;
+      // public: Length Duration() const;
+      public: std::chrono::steady_clock::duration Duration() const;
 
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored

--- a/av/include/ignition/common/Video.hh
+++ b/av/include/ignition/common/Video.hh
@@ -58,10 +58,14 @@ namespace ignition
       /// \return the height
       public: int Height() const;
 
+      /// \brief Convenience type alias for duration
+      /// where 1000000 is the same as AV_TIME_BASE fractional seconds
+      public:
+        using Length = std::chrono::duration<int64_t, std::ratio<1, 1000000>>;
+
       /// \brief Get the duration of the video
       /// \return the duration
-      // public: Length Duration() const;
-      public: std::chrono::steady_clock::duration Duration() const;
+      public: Length Duration() const;
 
       /// \brief Get the next frame of the video.
       /// \param[out] _img Image in which the frame is stored

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -289,3 +289,9 @@ int Video::Height() const
 {
   return this->dataPtr->codecCtx->height;
 }
+
+/////////////////////////////////////////////////
+int64_t Video::Duration() const
+{
+  return this->dataPtr->formatCtx->duration;
+}

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -291,7 +291,7 @@ int Video::Height() const
 }
 
 /////////////////////////////////////////////////
-int64_t Video::Duration() const
+std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>> Video::Duration() const
 {
-  return this->dataPtr->formatCtx->duration;
+  return std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>>(this->dataPtr->formatCtx->duration);
 }

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -291,8 +291,7 @@ int Video::Height() const
 }
 
 /////////////////////////////////////////////////
-std::chrono::steady_clock::duration Video::Duration() const
+Video::Length Video::Duration() const
 {
-  return std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>>(
-      this->dataPtr->formatCtx->duration);
+  return Video::Length(this->dataPtr->formatCtx->duration);
 }

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -291,7 +291,8 @@ int Video::Height() const
 }
 
 /////////////////////////////////////////////////
-Video::Length Video::Duration() const
+std::chrono::steady_clock::duration Video::Duration() const
 {
-  return Video::Length(this->dataPtr->formatCtx->duration);
+  return std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>>(
+      this->dataPtr->formatCtx->duration);
 }

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -291,7 +291,7 @@ int Video::Height() const
 }
 
 /////////////////////////////////////////////////
-std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>> Video::Duration() const
+Video::Length Video::Duration() const
 {
-  return std::chrono::duration<int64_t, std::ratio<1, AV_TIME_BASE>>(this->dataPtr->formatCtx->duration);
+  return Video::Length(this->dataPtr->formatCtx->duration);
 }

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -8,7 +8,8 @@ list(REMOVE_ITEM tests mesh.cc)
 
 ign_build_tests(
   TYPE INTEGRATION
-  SOURCES ${tests})
+  SOURCES ${tests}
+  LIB_DEPS ${PROJECT_LIBRARY_TARGET_NAME}-av)
 
 if(TARGET INTEGRATION_plugin)
   # We add this dependency to make sure that DummyPlugins gets generated

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Open Source Robotics Foundation
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#include <gtest/gtest.h>
+
+#include "ignition/common/VideoEncoder.hh"
+#include "ignition/common/Video.hh"
+#include "ignition/common/ffmpeg_inc.hh"
+#include "test_config.h"
+#include "test/util.hh"
+
+using namespace ignition;
+using namespace common;
+
+TEST(EncoderTimingTest, Duration)
+{
+  VideoEncoder vidEncoder;
+  vidEncoder.Start();
+
+  unsigned int size = 10;
+  unsigned char *frame = new unsigned char[size*size];
+
+  // int milliSec = (1.0/VIDEO_ENCODER_FPS_DEFAULT)*1000; // ms btwn frames
+  // for (int i = 0; i < VIDEO_ENCODER_FPS_DEFAULT; ++i)
+  // {
+  //   ASSERT_TRUE(vidEncoder.AddFrame(frame, size, size));
+  //   std::this_thread::sleep_for(std::chrono::milliseconds(milliSec));
+  // }
+
+  int frame_count = 0;
+  while (frame_count != VIDEO_ENCODER_FPS_DEFAULT)
+  {
+    if (vidEncoder.AddFrame(frame, size, size))
+      ++frame_count;
+  }
+
+  vidEncoder.Stop();
+
+  Video video;
+  std::string path = common::cwd() + "/TMP_RECORDING.mp4";
+  video.Load(path);
+
+  EXPECT_EQ(video.Duration()*1.0/AV_TIME_BASE, 1.0);
+  // EXPECT_EQ(video.Duration(), AV_TIME_BASE);
+}

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -25,7 +25,6 @@ using namespace common;
 
 const unsigned int kSize = 10;
 const unsigned char *kFrame = new unsigned char[kSize*kSize];
-const std::string kPath = common::cwd() + "/TMP_RECORDING.mp4";
 
 // set to 720ms because video duration missing additional 18 frames
 //    which may be due to how video encoding works
@@ -44,9 +43,10 @@ void durationTest(VideoEncoder &_vidEncoder, Video &_video,
   }
 
   _vidEncoder.Stop();
-  _video.Load(kPath);
+  _video.Load(common::cwd() + "/TMP_RECORDING.mp4");
 
-  EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(_video.Duration()).count(),
+  EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(
+                _video.Duration()).count(),
               _seconds*1000,
               kTol);
 }

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -14,7 +14,7 @@
  *
 */
 #include <gtest/gtest.h>
-
+#include <array>
 #include "ignition/common/VideoEncoder.hh"
 #include "ignition/common/Video.hh"
 #include "test_config.h"

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -46,7 +46,7 @@ void durationTest(VideoEncoder &_vidEncoder, Video &_video,
   _video.Load(common::cwd() + "/TMP_RECORDING.mp4");
 
   EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(
-                _video.Duration()).count(),
+              _video.Duration()).count(),
               _seconds*1000,
               kTol);
 }
@@ -57,7 +57,8 @@ TEST(EncoderTimingTest, Duration)
   Video video;
 
   durationTest(vidEncoder, video, 50, 1);
-  durationTest(vidEncoder, video, 30, 5);
-  durationTest(vidEncoder, video, 60, 10);
-  durationTest(vidEncoder, video, 25, 20);
+  durationTest(vidEncoder, video, 30, 2);
+  durationTest(vidEncoder, video, 25, 5);
+
+  delete [] kFrame;
 }

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -24,7 +24,7 @@ using namespace ignition;
 using namespace common;
 
 const unsigned int kSize = 10;
-const unsigned char *kFrame = new unsigned char[kSize*kSize];
+const std::array<unsigned char, kSize*kSize> kFrame = {};
 
 // set to 720ms because video duration missing additional 18 frames
 //    which may be due to how video encoding works
@@ -38,7 +38,7 @@ void durationTest(VideoEncoder &_vidEncoder, Video &_video,
   int frameCount = 0;
   while (frameCount != _fps*_seconds)
   {
-    if (_vidEncoder.AddFrame(kFrame, kSize, kSize))
+    if (_vidEncoder.AddFrame(kFrame.data(), kSize, kSize))
       ++frameCount;
   }
 
@@ -59,6 +59,4 @@ TEST(EncoderTimingTest, Duration)
   durationTest(vidEncoder, video, 50, 1);
   durationTest(vidEncoder, video, 30, 2);
   durationTest(vidEncoder, video, 25, 5);
-
-  delete [] kFrame;
 }

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -28,7 +28,7 @@ const unsigned char *kFrame = new unsigned char[kSize*kSize];
 
 // set to 720ms because video duration missing additional 18 frames
 //    which may be due to how video encoding works
-const int kTol = 720;
+const std::chrono::milliseconds kTol(720);
 
 void durationTest(VideoEncoder &_vidEncoder, Video &_video,
                   const int &_fps, const int &_seconds)
@@ -43,12 +43,12 @@ void durationTest(VideoEncoder &_vidEncoder, Video &_video,
   }
 
   _vidEncoder.Stop();
-  _video.Load(common::cwd() + "/TMP_RECORDING.mp4");
+  _video.Load(common::joinPaths(common::cwd(), "/TMP_RECORDING.mp4"));
 
   EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(
               _video.Duration()).count(),
               _seconds*1000,
-              kTol);
+              kTol.count());
 }
 
 TEST(EncoderTimingTest, Duration)


### PR DESCRIPTION
Test that verifies video encoder timing, which uses [VideoEncoder](https://github.com/ignitionrobotics/ign-common/blob/ign-common3/av/src/VideoEncoder.cc) to encode several frames to a video file and verifies the duration using the [Video](https://github.com/ignitionrobotics/ign-common/blob/encoder_timing_test/av/src/Video.cc) class with a new `Duration()` function. 