### PR TITLE
Little fixes for video encoder

### DIFF
--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -510,7 +510,8 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
 
   // Skip frames that arrive faster than the video's fps
   double period = 1.0/this->dataPtr->fps;
-  if (dt < std::chrono::duration<double>(period))
+  if (this->dataPtr->frameCount > 0u &&
+      dt < std::chrono::duration<double>(period))
     return false;
 
   if (this->dataPtr->frameCount == 0u)

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -777,4 +777,6 @@ void VideoEncoder::Reset()
   this->dataPtr->bitRate = VIDEO_ENCODER_BITRATE_DEFAULT;
   this->dataPtr->fps = VIDEO_ENCODER_FPS_DEFAULT;
   this->dataPtr->format = VIDEO_ENCODER_FORMAT_DEFAULT;
+  this->dataPtr->timePrev = std::chrono::steady_clock::time_point();
+  this->dataPtr->timeStart = std::chrono::steady_clock::time_point();
 }


### PR DESCRIPTION
I've played around with the video encoder and found (and fixed) the following little issues.

1. If you try to encode a video and supply a zero timestamp as the time of the first frame, it gets skipped.

1. Reset() did not reset timeStart and timePrev. Reset of timeStart is not technically needed, because Start() would correctly set it correctly based on the reset-ted value of frameCount. However, resetting it doesn't hurt anything. On the other hand, timePrev remained at its last value before Reset() call, which might lead to skipping the first frame of another video recording.