### PR TITLE
ci: remove two known flaky tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ project(ignition-common3 VERSION 3.7.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 REQUIRED)
+find_package(ignition-cmake2 REQUIRED COMPONENTS utilities)
+set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
 #============================================================================
 # Configure the project

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,6 +31,8 @@ endif()
 ign_build_tests(
   TYPE UNIT
   SOURCES ${gtest_sources}
+  LIB_DEPS
+    ignition-cmake${IGN_CMAKE_VER}::utilities
   INCLUDE_DIRS
     # Used to make internal source file headers visible to the unit tests
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -100,7 +100,7 @@ TEST(WorkerPool, WaitWithTimeout)
 //////////////////////////////////////////////////
 // /TODO(anyone) Deflake this test
 // ref: https://github.com/ignitionrobotics/ign-common/issues/52
-TEST(WorkerPool, 
+TEST(WorkerPool,
      IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WaitWithTimeoutThatTimesOut))
 {
   WorkerPool pool;
@@ -115,7 +115,7 @@ TEST(WorkerPool,
 //////////////////////////////////////////////////
 // /TODO(anyone) Deflake this test
 // ref: https://github.com/ignitionrobotics/ign-common/issues/53
-TEST(WorkerPool, 
+TEST(WorkerPool,
      IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ThingsRunInParallel))
 {
   const unsigned int hc = std::thread::hardware_concurrency();

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -100,7 +100,8 @@ TEST(WorkerPool, WaitWithTimeout)
 //////////////////////////////////////////////////
 // /TODO(anyone) Deflake this test
 // ref: https://github.com/ignitionrobotics/ign-common/issues/52
-TEST(WorkerPool, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WaitWithTimeoutThatTimesOut))
+TEST(WorkerPool, 
+     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WaitWithTimeoutThatTimesOut))
 {
   WorkerPool pool;
   pool.AddWork([] ()
@@ -114,7 +115,8 @@ TEST(WorkerPool, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(WaitWithTimeoutThatTimesOu
 //////////////////////////////////////////////////
 // /TODO(anyone) Deflake this test
 // ref: https://github.com/ignitionrobotics/ign-common/issues/53
-TEST(WorkerPool, IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ThingsRunInParallel))
+TEST(WorkerPool, 
+     IGN_UTILS_TEST_ENABLED_ONLY_ON_LINUX(ThingsRunInParallel))
 {
   const unsigned int hc = std::thread::hardware_concurrency();
   if (2 > hc)


### PR DESCRIPTION
These two have a history of turning builds red, and already have tracking issues:

* #52 
* #53 

They will still compile, just not run on non-Linux platforms.

Signed-off-by: Michael Carroll <michael@openrobotics.org>