### PR TITLE
Disable AV integration test when component not available

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -6,7 +6,7 @@ ign_get_sources(tests)
 # FIXME the mesh test does not work
 list(REMOVE_ITEM tests mesh.cc)
 
-if (WIN32)
+if (${SKIP_av})
   list(REMOVE_ITEM tests encoder_timing.cc)
 endif()
 

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -6,14 +6,22 @@ ign_get_sources(tests)
 # FIXME the mesh test does not work
 list(REMOVE_ITEM tests mesh.cc)
 
+if (WIN32)
+  list(REMOVE_ITEM tests encoder_timing.cc)
+endif()
+
 ign_build_tests(
   TYPE INTEGRATION
   SOURCES ${tests}
-  LIB_DEPS ${PROJECT_LIBRARY_TARGET_NAME}-av)
+)
 
 if(TARGET INTEGRATION_plugin)
   # We add this dependency to make sure that DummyPlugins gets generated
   # before INTEGRATION_plugin so that its auto-generated header is available.
   # We do not want to link INTEGRATION_plugin to the DummyPlugins library.
   add_dependencies(INTEGRATION_plugin IGNDummyPlugins)
+endif()
+
+if(TARGET INTEGRATION_encoder_timing)
+  target_link_libraries(INTEGRATION_encoder_timing ${PROJECT_LIBRARY_TARGET_NAME}-av)
 endif()


### PR DESCRIPTION
Disable the encoder integration test, which depends on the `av` component, which is currently not building on Windows.

I originally wanted to check for the `av` target first via:

```
if (NOT TARGET ${PROJECT_LIBRARY_TARGET_NAME}-av)
  list(REMOVE_ITEM tests encoder_timing.cc)
endif()
```

But because integration tests are configured _before_ components, those targets don't exist yet.  I'm not sure if this could be considered a bug in ign-cmake.

Signed-off-by: Michael Carroll <michael@openrobotics.org>