### PR TITLE
Fix IGN_HOMEDIR on Windows

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -30,6 +30,8 @@ release will remove the deprecated code.
 
 1. Requires c++17.
 
+1. (New in 3.8.0) On Windows, the value of C++ macro `IGN_HOMEDIR` changed from `HOMEPATH` to `USERPROFILE`. It is usually used to read the path to the user's home from environment. The old value pointed to a path relative to the (a) current drive letter as reported by `pwd`, not the system drive letter. The new value correctly points to an environment variable that contains the full absolute path to the user's profile. If the code did not use the macro in some unexpected way, the new behavior should work either the same or even better (it would work even when the current directory is on a non-system drive). If the code relied on this value to be relative to the current drive letter, it needs to be changed to use `HOMEPATH` directly.
+
 ## Ignition Common 1.X to 2.X
 
 ### Modifications

--- a/include/ignition/common/Util.hh
+++ b/include/ignition/common/Util.hh
@@ -32,7 +32,7 @@
 // Defines
 
 #ifdef _WIN32
-# define IGN_HOMEDIR "HOMEPATH"
+# define IGN_HOMEDIR "USERPROFILE"
 #else
 # define IGN_HOMEDIR "HOME"
 #endif


### PR DESCRIPTION
HOMEPATH alone is a pretty wicked concept. For its use to make sense, it has to be joined with HOMEDRIVE, because HOMEPATH is a path relative to HOMEDRIVE. So when you lookup just env("HOMEPATH") and use it as a file path, it gets resolved relative to any random drive letter that currently happens to be in CWD. I guess this could not be the inteded behavior.

USERPROFILE, on the other hand, contains the full absolute path to the user's home directory.

I looked through most libraries in github.com/ignitionrobotics, and none seemed to use IGN_HOMEDIR in a way that would assume the previous (wrong) value on Windows.

I don't consider this change a API or ABI break (the only thing it could break is already broken code :) ). However, as it is a change of a macro definition, it would need a re-release of all downstream libraries. But only on Windows :) And if I'm not mistaken, there are no binary builds for Windows yet, so that shouldn't be a problem (workspaces of people building from source would get correctly rebuilt automatically).