### PR TITLE
Fix Windows AV CI warnings and test failures

### DIFF
--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -96,13 +96,13 @@ TEST(AudioDecoder, CheerFile)
   EXPECT_FALSE(audio.SetFile("_bad_audio_filename_.wav"));
 
   // Test no stream info
-  std::string path = TEST_PATH;
-  path += "/data/audio_bad_codec.grf";
+  auto path = common::joinPaths(TEST_PATH, "data", "audio_bad_codec.grf");
+  EXPECT_FALSE(common::exists(path));
   EXPECT_FALSE(audio.SetFile(path));
 
   // Test a valid file without an audio stream
-  path = TEST_PATH;
-  path += "/data/empty_audio.mp4";
+  path = common::joinPaths(TEST_PATH, "data", "empty_audio.mp4");
+  ASSERT_TRUE(common::exists(path));
   EXPECT_FALSE(audio.SetFile(path));
 
   unsigned int dataBufferSize;
@@ -110,8 +110,8 @@ TEST(AudioDecoder, CheerFile)
 
   // WAV
   {
-    path = TEST_PATH;
-    path += "/data/cheer.wav";
+    path = common::joinPaths(TEST_PATH, "data", "cheer.wav");
+    ASSERT_TRUE(common::exists(path));
     EXPECT_TRUE(audio.SetFile(path));
     EXPECT_EQ(audio.File(), path);
     EXPECT_EQ(audio.SampleRate(), 48000);
@@ -122,8 +122,8 @@ TEST(AudioDecoder, CheerFile)
 
   // OGG
   {
-    path = TEST_PATH;
-    path += "/data/cheer.ogg";
+    path = common::joinPaths(TEST_PATH, "data", "cheer.ogg");
+    ASSERT_TRUE(common::exists(path));
     EXPECT_TRUE(audio.SetFile(path));
     EXPECT_EQ(audio.File(), path);
     EXPECT_EQ(audio.SampleRate(), 44100);
@@ -137,8 +137,8 @@ TEST(AudioDecoder, CheerFile)
 
   // MP3
   {
-    path = TEST_PATH;
-    path += "/data/cheer.mp3";
+    path = common::joinPaths(TEST_PATH, "data", "cheer.mp3");
+    ASSERT_TRUE(common::exists(path));
     EXPECT_TRUE(audio.SetFile(path));
     EXPECT_EQ(audio.File(), path);
     EXPECT_EQ(audio.SampleRate(), 44100);

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -588,7 +588,7 @@ bool VideoEncoder::AddFrame(const unsigned char *_frame,
   auto timeSinceStart = std::chrono::duration_cast<std::chrono::milliseconds>(
       _timestamp - this->dataPtr->timeStart);
   double durationSec = timeSinceStart.count() / 1000.0;
-  uint64_t frameNumber = durationSec / period;
+  uint64_t frameNumber = static_cast<uint64_t>(durationSec / period);
 
   uint64_t frameDiff = frameNumber + 1 - this->dataPtr->frameCount;
 

--- a/av/src/VideoEncoder_TEST.cc
+++ b/av/src/VideoEncoder_TEST.cc
@@ -33,19 +33,22 @@ TEST_F(VideoEncoderTest, StartStop)
   EXPECT_EQ(video.BitRate(), static_cast<unsigned int>(
         VIDEO_ENCODER_BITRATE_DEFAULT));
 
+  auto filePathMp4 = common::joinPaths(common::cwd(), "TMP_RECORDING.mp4");
+  auto filePathMpg = common::joinPaths(common::cwd(), "TMP_RECORDING.mpg");
+
   video.Start();
   EXPECT_TRUE(video.IsEncoding());
-  EXPECT_TRUE(common::exists(common::cwd() + "/TMP_RECORDING.mp4"));
+  EXPECT_TRUE(common::exists(filePathMp4));
   EXPECT_EQ(video.BitRate(), 920000u);
 
   video.Stop();
   EXPECT_FALSE(video.IsEncoding());
-  EXPECT_FALSE(common::exists(common::cwd() + "/TMP_RECORDING.mpg"));
+  EXPECT_FALSE(common::exists(filePathMpg));
 
   video.Start("mpg", "", 1024, 768);
   EXPECT_TRUE(video.IsEncoding());
   EXPECT_STREQ(video.Format().c_str(), "mpg");
-  EXPECT_TRUE(common::exists(common::cwd() + "/TMP_RECORDING.mpg"));
+  EXPECT_TRUE(common::exists(filePathMpg));
 
   video.Start("mp4", "", 1024, 768);
   EXPECT_TRUE(video.IsEncoding());
@@ -62,12 +65,15 @@ TEST_F(VideoEncoderTest, Exists)
   EXPECT_FALSE(video.IsEncoding());
   EXPECT_STREQ(video.Format().c_str(), VIDEO_ENCODER_FORMAT_DEFAULT);
 
-  EXPECT_FALSE(common::exists(common::cwd() + "/TMP_RECORDING.mpg"));
-  EXPECT_FALSE(common::exists(common::cwd() + "/TMP_RECORDING.mp4"));
+  auto filePathMp4 = common::joinPaths(common::cwd(), "TMP_RECORDING.mp4");
+  auto filePathMpg = common::joinPaths(common::cwd(), "TMP_RECORDING.mpg");
+
+  EXPECT_FALSE(common::exists(filePathMp4));
+  EXPECT_FALSE(common::exists(filePathMpg));
 
   video.Start();
-  EXPECT_TRUE(common::exists(common::cwd() + "/TMP_RECORDING.mp4"));
+  EXPECT_TRUE(common::exists(filePathMp4));
 
   video.Reset();
-  EXPECT_FALSE(common::exists(common::cwd() + "/TMP_RECORDING.mp4"));
+  EXPECT_FALSE(common::exists(filePathMp4));
 }

--- a/test/integration/encoder_timing.cc
+++ b/test/integration/encoder_timing.cc
@@ -45,10 +45,13 @@ void durationTest(VideoEncoder &_vidEncoder, Video &_video,
   _vidEncoder.Stop();
   _video.Load(common::joinPaths(common::cwd(), "/TMP_RECORDING.mp4"));
 
-  EXPECT_NEAR(std::chrono::duration_cast<std::chrono::milliseconds>(
-              _video.Duration()).count(),
-              _seconds*1000,
-              kTol.count());
+  auto length = std::chrono::duration_cast<std::chrono::milliseconds>(
+      _video.Duration()).count();
+
+  // Static cast to suppress Windows warning
+  EXPECT_NEAR(static_cast<double>(length),
+              static_cast<double>(_seconds*1000),
+              static_cast<double>(kTol.count()));
 }
 
 TEST(EncoderTimingTest, Duration)


### PR DESCRIPTION
I believe that these were introduced by changes in the Windows hosts, allowing the `av` component to be built and tested, so not necessarily a regression.

Signed-off-by: Michael Carroll <michael@openrobotics.org>