### PR TITLE
Added render order to material class

### DIFF
--- a/graphics/include/ignition/common/Material.hh
+++ b/graphics/include/ignition/common/Material.hh
@@ -177,6 +177,15 @@ namespace ignition
       /// \return The enable two sided rendering value
       public: bool TwoSidedEnabled() const;
 
+      /// \brief Set the render order. The higher value will be rendered on top
+      /// of the other coplanar polygons.
+      /// \param[in] _renderOrder The render order value
+      public: void SetRenderOrder(float _renderOrder);
+
+      /// \brief Get the render order
+      /// \return The render order value
+      public: float RenderOrder() const;
+
       /// \brief Set the shininess
       /// \param[in] _t The shininess value
       public: void SetShininess(double _t);
@@ -265,6 +274,7 @@ namespace ignition
                 _out << "  Emissive: " << _m.Emissive() << "\n";
                 _out << "  Transparency: " << _m.Transparency() << "\n";
                 _out << "  Shininess: " << _m.Shininess() << "\n";
+                _out << "  Render order: " << _m.RenderOrder() << "\n";
                 _out << "  BlendMode: " << _m.BlendStr() << "\n";
                 _out << "  ShadeMode: " << _m.ShadeStr() << "\n";
                 _out << "  DepthWrite: " << _m.DepthWrite() << "\n";

--- a/graphics/src/Material.cc
+++ b/graphics/src/Material.cc
@@ -64,6 +64,9 @@ class ignition::common::MaterialPrivate
   // \brief Enables two sided rendering
   public: bool twoSidedEnabled = false;
 
+  /// \brief render order value
+  public: int renderOrder = 0.0;
+
   /// \brief shininess value (0 to 1)
   public: double shininess = 0.0;
 
@@ -269,6 +272,18 @@ void Material::SetShininess(double _s)
 double Material::Shininess() const
 {
   return this->dataPtr->shininess;
+}
+
+//////////////////////////////////////////////////
+void Material::SetRenderOrder(float _renderOrder)
+{
+  this->dataPtr->renderOrder = _renderOrder;
+}
+
+//////////////////////////////////////////////////
+float Material::RenderOrder() const
+{
+  return this->dataPtr->renderOrder;
 }
 
 //////////////////////////////////////////////////

--- a/graphics/src/Material.cc
+++ b/graphics/src/Material.cc
@@ -65,7 +65,7 @@ class ignition::common::MaterialPrivate
   public: bool twoSidedEnabled = false;
 
   /// \brief render order value
-  public: int renderOrder = 0.0;
+  public: float renderOrder = 0.0;
 
   /// \brief shininess value (0 to 1)
   public: double shininess = 0.0;

--- a/graphics/src/Material_TEST.cc
+++ b/graphics/src/Material_TEST.cc
@@ -66,6 +66,9 @@ TEST_F(MaterialTest, Material)
   EXPECT_DOUBLE_EQ(mat.AlphaThreshold(), 0.3);
   EXPECT_EQ(mat.TwoSidedEnabled(), false);
 
+  mat.SetRenderOrder(4.0);
+  EXPECT_DOUBLE_EQ(4.0, mat.RenderOrder());
+
   mat.SetShininess(0.2);
   EXPECT_DOUBLE_EQ(0.2, mat.Shininess());
 


### PR DESCRIPTION
This PR is part of the effort to avoid z-fighting between coplanar meshes. 

Related with https://github.com/ignitionrobotics/ign-rendering/pull/188

Signed-off-by: ahcorde <ahcorde@gmail.com>