### PR TITLE
Add Windows installation; move installation in README to tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ encoding/decoding to thread pools.
 
 [Usage](#usage)
 
-[Documentation](#documentation)
-
-[Testing](#testing)
-
 [Folder Structure](#folder-structure)
 
 [Code of Conduct](#code-of-conduct)
@@ -65,54 +61,6 @@ See the [installation tutorial](https://ignitionrobotics.org/api/common/3.9/tuto
 # Usage
 
 Please refer to the [examples directory](https://github.com/ignitionrobotics/ign-common/raw/master/examples/).
-
-# Documentation
-
-API and tutorials can be found at [https://ignitionrobotics.org/libs/common](https://ignitionrobotics.org/libs/common).
-
-You can also generate the documentation from a clone of this repository by following these steps.
-
-1. You will need Doxygen. On Ubuntu Doxygen can be installed using
-
-    ```
-    sudo apt-get install doxygen
-    ```
-
-2. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-common
-    ```
-
-3. Configure and build the documentation.
-
-    ```
-    cd ign-common; mkdir build; cd build; cmake ../; make doc
-    ```
-
-4. View the documentation by running the following command from the build directory.
-
-    ```
-    firefox doxygen/html/index.html
-    ```
-
-# Testing
-
-Follow these steps to run tests and static code analysis in your clone of this repository.
-
-1. Follow the [source install instruction](#source-install).
-
-2. Run tests.
-
-    ```
-    make test
-    ```
-
-3. Static code checker.
-
-    ```
-    make codecheck
-    ```
 
 # Folder Structure
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,6 @@ encoding/decoding to thread pools.
 
 [Install](#install)
 
-* [Binary Install](#binary-install)
-
-* [Source Install](#source-install)
-
-    * [Prerequisites](#prerequisites)
-
-    * [Building from Source](#building-from-source)
-
 [Usage](#usage)
 
 [Documentation](#documentation)
@@ -68,67 +60,7 @@ callback system.
 
 # Install
 
-We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
-
-The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
-
-## Binary Install
-
-On Ubuntu systems, `apt-get` can be used to install `ignition-common`:
-
-```
-sudo apt install libignition-common<#>-dev
-```
-
-Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
-which version you need.
-
-## Source Install
-
-Source installation can be performed in UNIX systems by first installing the
-necessary prerequisites followed by building from source.
-
-### Prerequisites
-
-Ignition Common requires:
-
-  * [Ignition CMake](https://ignitionrobotics.org/libs/cmake)
-  * [Ignition Math](https://ignitionrobotics.org/libs/math).
-
-The Graphics component requires:
-
-  * [FreeImage](http://freeimage.sourceforge.net/)
-  * [GTS](http://gts.sourceforge.net/).
-
-The AV component requires:
-
-  * [libswscale](https://www.ffmpeg.org/libswscale.html)
-  * [libavdevice](https://www.ffmpeg.org/libavdevice.html)
-  * [libavformat](https://www.ffmpeg.org/libavformat.html)
-  * [libavcodec](https://www.ffmpeg.org/libavcodec.html)
-  * [libavutil](https://www.ffmpeg.org/libavutil.html)
-
-### Building from source
-
-1. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-common
-    ```
-
-2. Install the [Prerequisites](#prerequisites).
-
-3. Configure and build
-
-    ```
-    cd ign-common; mkdir build;cd build; cmake ..;  make
-    ```
-
-4. Optionally, install Ignition Common
-
-    ```
-    sudo make install
-    ```
+See the [installation tutorial](https://ignitionrobotics.org/api/common/3.9/tutorials.html).
 
 # Usage
 

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -6,6 +6,7 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 
 **The tutorials**
 
+1. \subpage install "Installation"
 1. \subpage profiler "Profiler"
 
 ## License

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -5,11 +5,11 @@ Next Tutorial: \ref profiler
 These instructions are for installing only Ignition Common.
 If you're interested in using all the Ignition libraries, check out this [Ignition installation](https://ignitionrobotics.org/docs/latest/install).
 
-We recommend following the Binary Install instructions to get up and running as quickly and painlessly as possible.
+We recommend following the Binary Installation instructions to get up and running as quickly and painlessly as possible.
 
-The Source Install instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
+The Source Installation instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
 
-# Binary Install
+# Binary Installation
 
 ## Ubuntu
 
@@ -40,7 +40,7 @@ conda install libignition-common<#> --channel conda-forge
 Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
 which version you need.
 
-# Source Install
+# Source Installation
 
 Source installation can be performed by first installing the necessary
 prerequisites followed by building from source.
@@ -93,7 +93,7 @@ Install dependencies, replacing `<#>` with the desired versions:
 conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
 ```
 
-## Building from Source
+## Build from Source
 
 ### Ubuntu
 
@@ -111,14 +111,14 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   make
   ```
 
-3. Optionally, install Ignition Common
+3. Optionally, install
   ```
   sudo make install
   ```
 
 ### Windows
 
-This assumes you have created and activated a Conda environment while installing the Dependencies.
+This assumes you have created and activated a Conda environment while installing the Prerequisites.
 
 1. Navigate to where you would like to build the library, and clone the repository.
   ```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -147,28 +147,28 @@ API and tutorials can be found at [https://ignitionrobotics.org/libs/common](htt
 You can also generate the documentation from a clone of this repository by following these steps.
 
 1. You will need Doxygen. On Ubuntu Doxygen can be installed using
-
-    ```
-    sudo apt-get install doxygen
-    ```
+  ```
+  sudo apt-get install doxygen
+  ```
 
 2. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-common
-    ```
+  ```
+  git clone https://github.com/ignitionrobotics/ign-common
+  ```
 
 3. Configure and build the documentation.
-
-    ```
-    cd ign-common; mkdir build; cd build; cmake ../; make doc
-    ```
+  ```
+  cd ign-common
+  mkdir build
+  cd build
+  cmake ../
+  make doc
+  ```
 
 4. View the documentation by running the following command from the build directory.
-
-    ```
-    firefox doxygen/html/index.html
-    ```
+  ```
+  firefox doxygen/html/index.html
+  ```
 
 # Testing
 
@@ -177,14 +177,12 @@ Follow these steps to run tests and static code analysis in your clone of this r
 1. Follow the [source install instruction](#source-install).
 
 2. Run tests.
-
-    ```
-    make test
-    ```
+  ```
+  make test
+  ```
 
 3. Static code checker.
-
-    ```
-    make codecheck
-    ```
+  ```
+  make codecheck
+  ```
 

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -139,3 +139,52 @@ This assumes you have created and activated a Conda environment while installing
   ```
   cmake --install . --config Release
   ```
+
+# Documentation
+
+API and tutorials can be found at [https://ignitionrobotics.org/libs/common](https://ignitionrobotics.org/libs/common).
+
+You can also generate the documentation from a clone of this repository by following these steps.
+
+1. You will need Doxygen. On Ubuntu Doxygen can be installed using
+
+    ```
+    sudo apt-get install doxygen
+    ```
+
+2. Clone the repository
+
+    ```
+    git clone https://github.com/ignitionrobotics/ign-common
+    ```
+
+3. Configure and build the documentation.
+
+    ```
+    cd ign-common; mkdir build; cd build; cmake ../; make doc
+    ```
+
+4. View the documentation by running the following command from the build directory.
+
+    ```
+    firefox doxygen/html/index.html
+    ```
+
+# Testing
+
+Follow these steps to run tests and static code analysis in your clone of this repository.
+
+1. Follow the [source install instruction](#source-install).
+
+2. Run tests.
+
+    ```
+    make test
+    ```
+
+3. Static code checker.
+
+    ```
+    make codecheck
+    ```
+

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -1,0 +1,145 @@
+\page install Installation
+
+Next Tutorial: \ref profiler
+
+# Install
+
+These instructions are for installing only Ignition Common.
+If you're interested in using all the Ignition libraries, check out this [Ignition installation](https://ignitionrobotics.org/docs/latest/install).
+
+We recommend following the Binary Install instructions to get up and running as quickly and painlessly as possible.
+
+The Source Install instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
+
+## Binary Install
+
+### Ubuntu
+
+On Ubuntu systems, `apt-get` can be used to install `ignition-common`:
+
+```
+sudo apt install libignition-common<#>-dev
+```
+
+Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
+which version you need.
+
+### Windows
+
+Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
+Miniconda suffices.
+
+Create if necessary, and activate a Conda environment:
+
+    conda create -n ign-ws
+    conda activate ign-ws
+
+Install `ignition-common`:
+
+    conda install libignition-common<#> --channel conda-forge
+
+Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
+which version you need.
+
+## Source Install
+
+Source installation can be performed by first installing the necessary
+prerequisites followed by building from source.
+
+### Prerequisites
+
+Ignition Common requires:
+
+  * [Ignition CMake](https://ignitionrobotics.org/libs/cmake)
+  * [Ignition Math](https://ignitionrobotics.org/libs/math).
+
+The Graphics component requires:
+
+  * [FreeImage](http://freeimage.sourceforge.net/)
+  * [GTS](http://gts.sourceforge.net/).
+
+The AV component requires:
+
+  * [libswscale](https://www.ffmpeg.org/libswscale.html)
+  * [libavdevice](https://www.ffmpeg.org/libavdevice.html)
+  * [libavformat](https://www.ffmpeg.org/libavformat.html)
+  * [libavcodec](https://www.ffmpeg.org/libavcodec.html)
+  * [libavutil](https://www.ffmpeg.org/libavutil.html)
+
+#### Windows
+
+First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
+
+Install prerequisites:
+
+    ```
+    conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
+    ```
+
+Install Ignition dependencies:
+
+You can view the list of dependencies, replacing `<#>` with the desired version:
+
+    ```
+    conda search libignition-common<#> --channel conda-forge --info
+    ```
+
+Install dependencies, replacing `<#>` with the desired versions:
+ 
+    ```
+    conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
+    ```
+
+### Building from source
+
+#### Ubuntu
+
+1. Clone the repository
+
+    ```
+    git clone https://github.com/ignitionrobotics/ign-common
+    ```
+
+1. Configure and build
+
+    ```
+    cd ign-common; mkdir build;cd build; cmake ..;  make
+    ```
+
+1. Optionally, install Ignition Common
+
+    ```
+    sudo make install
+    ```
+
+#### Windows
+
+1. Navigate to ``condabin`` if necessary to use the ``conda`` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of ``condabin`` in Anaconda Prompt, ``where conda``).
+   Activate the Conda environment with prerequisites installed:
+
+    ```
+    conda activate ign-ws
+    ```
+
+1. Navigate to where you would like to build the library, and clone the repository.
+
+    ```
+    # This checks out the `main` branch. You can append `-b ign-common#` (replace # with a number) to checkout a specific version
+    git clone https://github.com/ignitionrobotics/ign-common.git
+    ```
+
+1. Configure and build
+
+    ```
+    cd ign-common
+    mkdir build
+    cd build
+    cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+    cmake --build . --config Release
+    ```
+
+1. Optionally, install
+
+    ```
+    cmake --install . --config Release
+    ```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -74,7 +74,7 @@ The AV component requires:
 
 First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
 
-Navigate to ``condabin`` if necessary to use the ``conda`` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of ``condabin`` in Anaconda Prompt, ``where conda``).
+Navigate to `condabin` if necessary to use the `conda` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of `condabin` in Anaconda Prompt, `where conda`).
 
 Activate the Conda environment:
 
@@ -107,44 +107,42 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
 #### Ubuntu
 
 1. Clone the repository
-
-    ```
-    git clone https://github.com/ignitionrobotics/ign-common
-    ```
+  ```
+  git clone https://github.com/ignitionrobotics/ign-common
+  ```
 
 1. Configure and build
-
-    ```
-    cd ign-common; mkdir build;cd build; cmake ..;  make
-    ```
+  ```
+  cd ign-common
+  mkdir build
+  cd build
+  cmake ..
+  make
+  ```
 
 1. Optionally, install Ignition Common
-
-    ```
-    sudo make install
-    ```
+  ```
+  sudo make install
+  ```
 
 #### Windows
 
 1. Navigate to where you would like to build the library, and clone the repository.
-
-    ```
-    # Optionally, append `-b ign-common#` (replace # with a number) to check out a specific version
-    git clone https://github.com/ignitionrobotics/ign-common.git
-    ```
+  ```
+  # Optionally, append `-b ign-common#` (replace # with a number) to check out a specific version
+  git clone https://github.com/ignitionrobotics/ign-common.git
+  ```
 
 1. Configure and build
-
-    ```
-    cd ign-common
-    mkdir build
-    cd build
-    cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
-    cmake --build . --config Release
-    ```
+  ```
+  cd ign-common
+  mkdir build
+  cd build
+  cmake .. -DBUILD_TESTING=OFF  # Optionally, -DCMAKE_INSTALL_PREFIX=path\to\install
+  cmake --build . --config Release
+  ```
 
 1. Optionally, install
-
-    ```
-    cmake --install . --config Release
-    ```
+  ```
+  cmake --install . --config Release
+  ```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -111,7 +111,7 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   git clone https://github.com/ignitionrobotics/ign-common
   ```
 
-1. Configure and build
+2. Configure and build
   ```
   cd ign-common
   mkdir build
@@ -120,7 +120,7 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   make
   ```
 
-1. Optionally, install Ignition Common
+3. Optionally, install Ignition Common
   ```
   sudo make install
   ```
@@ -133,7 +133,7 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   git clone https://github.com/ignitionrobotics/ign-common.git
   ```
 
-1. Configure and build
+2. Configure and build
   ```
   cd ign-common
   mkdir build
@@ -142,7 +142,7 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   cmake --build . --config Release
   ```
 
-1. Optionally, install
+3. Optionally, install
   ```
   cmake --install . --config Release
   ```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -42,7 +42,7 @@ Install `ignition-common`:
 conda install libignition-common<#> --channel conda-forge
 ```
 
-Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
+Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
 which version you need.
 
 ## Source Install

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -2,8 +2,6 @@
 
 Next Tutorial: \ref profiler
 
-# Install
-
 These instructions are for installing only Ignition Common.
 If you're interested in using all the Ignition libraries, check out this [Ignition installation](https://ignitionrobotics.org/docs/latest/install).
 
@@ -11,12 +9,11 @@ We recommend following the Binary Install instructions to get up and running as 
 
 The Source Install instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
 
-## Binary Install
+# Binary Install
 
-### Ubuntu
+## Ubuntu
 
 On Ubuntu systems, `apt-get` can be used to install `ignition-common`:
-
 ```
 sudo apt install libignition-common<#>-dev
 ```
@@ -24,20 +21,18 @@ sudo apt install libignition-common<#>-dev
 Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
 which version you need.
 
-### Windows
+## Windows
 
 Install [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
 Miniconda suffices.
 
 Create if necessary, and activate a Conda environment:
-
 ```
 conda create -n ign-ws
 conda activate ign-ws
 ```
 
 Install `ignition-common`:
-
 ```
 conda install libignition-common<#> --channel conda-forge
 ```
@@ -45,12 +40,12 @@ conda install libignition-common<#> --channel conda-forge
 Be sure to replace `<#>` with a number value, such as 2 or 3, depending on
 which version you need.
 
-## Source Install
+# Source Install
 
 Source installation can be performed by first installing the necessary
 prerequisites followed by building from source.
 
-### Prerequisites
+## Prerequisites
 
 Ignition Common requires:
 
@@ -70,20 +65,18 @@ The AV component requires:
   * [libavcodec](https://www.ffmpeg.org/libavcodec.html)
   * [libavutil](https://www.ffmpeg.org/libavutil.html)
 
-#### Windows
+### Windows
 
 First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
 
 Navigate to `condabin` if necessary to use the `conda` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of `condabin` in Anaconda Prompt, `where conda`).
 
 Activate the Conda environment:
-
 ```
 conda activate ign-ws
 ```
 
 Install prerequisites:
-
 ```
 conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
 ```
@@ -91,20 +84,18 @@ conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
 Install Ignition dependencies:
 
 You can view available versions and their dependencies:
-
 ```
 conda search libignition-common* --channel conda-forge --info
 ```
 
 Install dependencies, replacing `<#>` with the desired versions:
-
 ```
 conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
 ```
 
-### Building from source
+## Building from Source
 
-#### Ubuntu
+### Ubuntu
 
 1. Clone the repository
   ```
@@ -125,7 +116,9 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
   sudo make install
   ```
 
-#### Windows
+### Windows
+
+This assumes you have created and activated a Conda environment while installing the Dependencies.
 
 1. Navigate to where you would like to build the library, and clone the repository.
   ```

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -31,12 +31,16 @@ Miniconda suffices.
 
 Create if necessary, and activate a Conda environment:
 
-    conda create -n ign-ws
-    conda activate ign-ws
+```
+conda create -n ign-ws
+conda activate ign-ws
+```
 
 Install `ignition-common`:
 
-    conda install libignition-common<#> --channel conda-forge
+```
+conda install libignition-common<#> --channel conda-forge
+```
 
 Be sure to replace `<#>` with a number value, such as 1 or 2, depending on
 which version you need.
@@ -72,23 +76,23 @@ First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tut
 
 Install prerequisites:
 
-    ```
-    conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
-    ```
+```
+conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
+```
 
 Install Ignition dependencies:
 
 You can view the list of dependencies, replacing `<#>` with the desired version:
 
-    ```
-    conda search libignition-common<#> --channel conda-forge --info
-    ```
+```
+conda search libignition-common<#> --channel conda-forge --info
+```
 
 Install dependencies, replacing `<#>` with the desired versions:
  
-    ```
-    conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
-    ```
+```
+conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
+```
 
 ### Building from source
 

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -74,6 +74,14 @@ The AV component requires:
 
 First, follow the [ign-cmake](https://github.com/ignitionrobotics/ign-cmake) tutorial for installing Conda, Visual Studio, CMake, etc., prerequisites, and creating a Conda environment.
 
+Navigate to ``condabin`` if necessary to use the ``conda`` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of ``condabin`` in Anaconda Prompt, ``where conda``).
+
+Activate the Conda environment:
+
+```
+conda activate ign-ws
+```
+
 Install prerequisites:
 
 ```
@@ -82,14 +90,14 @@ conda install freeimage gts glib dlfcn-win32 ffmpeg --channel conda-forge
 
 Install Ignition dependencies:
 
-You can view the list of dependencies, replacing `<#>` with the desired version:
+You can view available versions and their dependencies:
 
 ```
-conda search libignition-common<#> --channel conda-forge --info
+conda search libignition-common* --channel conda-forge --info
 ```
 
 Install dependencies, replacing `<#>` with the desired versions:
- 
+
 ```
 conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
 ```
@@ -118,17 +126,10 @@ conda install libignition-cmake<#> libignition-math<#> --channel conda-forge
 
 #### Windows
 
-1. Navigate to ``condabin`` if necessary to use the ``conda`` command (i.e., if Conda is not in your `PATH` environment variable. You can find the location of ``condabin`` in Anaconda Prompt, ``where conda``).
-   Activate the Conda environment with prerequisites installed:
-
-    ```
-    conda activate ign-ws
-    ```
-
 1. Navigate to where you would like to build the library, and clone the repository.
 
     ```
-    # This checks out the `main` branch. You can append `-b ign-common#` (replace # with a number) to checkout a specific version
+    # Optionally, append `-b ign-common#` (replace # with a number) to check out a specific version
     git clone https://github.com/ignitionrobotics/ign-common.git
     ```
 

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -127,16 +127,15 @@ If the profiler is run successfully, you should see output in a browser. Similar
 If you see ``connection error``, there are a couple of things to double check
 1. Was the profiler enabled when the project you're trying to run was compiled? Note that this isn't the case if you installed Ignition libraries from binaries, for example. You need to compile the project from source with the `ENABLE_PROFILER` variable set.
 2. Are you using the correct port number in the upper left corner ``Connection Addresss: ws://127.0.0.1:1500/rmt``? Running ``ign gazebo -v 4`` will show the port number in use near the top of the outputted text. The port number will be printed out if the profiler is enabled. 
-
-    ```{.sh}
-    [Dbg] [RemoteryProfilerImpl.cc:187] Starting ign-common profiler impl: Remotery (port: 1500)
-    ```
+  ```{.sh}
+  [Dbg] [RemoteryProfilerImpl.cc:187] Starting ign-common profiler impl: Remotery (port: 1500)
+  ```
 3. Are you running the program in a separate terminal? The profiler only establishes connection if there is a program running and being actively profiled.
 
 4. If you want to use a different port, configure the environment variable `RMT_PORT` by running the following in terminal, and update the web viewer port in your browser accordingly (see 2 above)
-    ```{.sh}
-    export RMT_PORT=1500
-    ```
+  ```{.sh}
+  export RMT_PORT=1500
+  ```
 
 
 ## Using the Profiler


### PR DESCRIPTION
Partially addresses https://github.com/ignitionrobotics/docs/issues/117 and https://github.com/ignitionrobotics/docs/issues/14#issuecomment-750431388 .

- Adds Windows binary and from source install instructions for https://github.com/ignitionrobotics/docs/issues/117 .
   For some reason, I didn't encounter the compilation error @Jshep1 mentioned here https://github.com/ignitionrobotics/docs/issues/96#issuecomment-742096017 .
   My steps are slightly different, as necessitated by these per-package installation tutorials.
   John built everything from source using `colcon`.
   I did `conda-forge` binary install for `ign-cmake` and `ign-math`, and then pure `cmake`.
   Not sure if that makes the difference or I'm missing something.

- Moves installation in README to a new installation tutorial page for https://github.com/ignitionrobotics/docs/issues/14#issuecomment-750431388 .
   TODO: The URL in README currently links to `ign-common` tutorials main page, since the installation tutorial webpage doesn't exist yet. Somebody should change the link after this PR is deployed. Trivial fix of the URL in README line 63.
