### PR TITLE
Fix memory leak in Pbr.cc

### DIFF
--- a/graphics/src/Pbr.cc
+++ b/graphics/src/Pbr.cc
@@ -110,6 +110,10 @@ Pbr &Pbr::operator=(const Pbr &_pbr)
 /////////////////////////////////////////////////
 Pbr &Pbr::operator=(Pbr &&_pbr)
 {
+  if (this->dataPtr)
+  {
+    delete this->dataPtr;
+  }
   this->dataPtr = _pbr.dataPtr;
   _pbr.dataPtr = nullptr;
   return *this;


### PR DESCRIPTION
Caught with Address Sanitizer. Acording to ASAN, Pbr.MoveCopy test
would allocate PbrPrivate on Pbr_TEST.cc:177 and leak on
Pbr_TEST.cc:178.