### PR TITLE
Disable failing VideoEncoder and Audioecoder tests on Windows

### DIFF
--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/AudioDecoder.hh>
+#include <ignition/utilities/ExtraTestMacros.hh>
 
 #include "test/util.hh"
 #include "test_config.h"
@@ -88,7 +89,7 @@ TEST(AudioDecoder, NoCodec)
 }
 
 /////////////////////////////////////////////////
-TEST(AudioDecoder, CheerFile)
+TEST(AudioDecoder, IGN_UTILS_TEST_DISABLED_ON_WIN32(CheerFile))
 {
   common::AudioDecoder audio;
 
@@ -106,7 +107,7 @@ TEST(AudioDecoder, CheerFile)
   EXPECT_FALSE(audio.SetFile(path));
 
   unsigned int dataBufferSize;
-  uint8_t *dataBuffer = NULL;
+  uint8_t *dataBuffer = nullptr;
 
   // WAV
   {

--- a/av/src/CMakeLists.txt
+++ b/av/src/CMakeLists.txt
@@ -11,4 +11,8 @@ target_link_libraries(${av_target}
     AVUTIL::AVUTIL)
 
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
-  LIB_DEPS ${av_target})
+  LIB_DEPS
+    ${av_target}
+    ignition-cmake${IGN_CMAKE_VER}::utilities
+)
+

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -136,7 +136,14 @@ bool VideoEncoder::Start(const std::string &_format,
 
   // Remove old temp file, if it exists.
   if (common::exists(this->dataPtr->filename))
-    std::remove(this->dataPtr->filename.c_str());
+  {
+    auto success = removeFile(this->dataPtr->filename.c_str());
+    if (!success)
+    {
+      ignerr << "Failed to remove temp file [" << this->dataPtr->filename
+             << "]" << std::endl;
+    }
+  }
 
   // Calculate a good bitrate if the _bitRate argument is zero
   if (_bitRate == 0)
@@ -174,7 +181,7 @@ bool VideoEncoder::Start(const std::string &_format,
   this->dataPtr->frameCount = 0;
   this->dataPtr->filename = _filename;
 
-  // Create a default filenamae if the provided filename is empty.
+  // Create a default filename if the provided filename is empty.
   if (this->dataPtr->filename.empty())
   {
     if (this->dataPtr->format.compare("v4l2") == 0)
@@ -768,7 +775,14 @@ void VideoEncoder::Reset()
 
   // Remove old temp file, if it exists.
   if (common::exists(this->dataPtr->filename))
-    std::remove(this->dataPtr->filename.c_str());
+  {
+    auto success = removeFile(this->dataPtr->filename.c_str());
+    if (!success)
+    {
+      ignerr << "Failed to remove temp file [" << this->dataPtr->filename
+             << "]" << std::endl;
+    }
+  }
 
   // set default values
   this->dataPtr->frameCount = 0;
@@ -780,4 +794,5 @@ void VideoEncoder::Reset()
   this->dataPtr->format = VIDEO_ENCODER_FORMAT_DEFAULT;
   this->dataPtr->timePrev = std::chrono::steady_clock::time_point();
   this->dataPtr->timeStart = std::chrono::steady_clock::time_point();
+  this->dataPtr->filename.clear();
 }

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -193,8 +193,8 @@ bool VideoEncoder::Start(const std::string &_format,
     }
     else
     {
-      this->dataPtr->filename = common::cwd() + "/TMP_RECORDING." +
-                                this->dataPtr->format;
+      this->dataPtr->filename = joinPaths(common::cwd(), "TMP_RECORDING." +
+                                this->dataPtr->format);
     }
   }
 

--- a/av/src/VideoEncoder_TEST.cc
+++ b/av/src/VideoEncoder_TEST.cc
@@ -68,8 +68,12 @@ TEST_F(VideoEncoderTest, StartStop)
   }
 
   // Check that temp files are removed when video goes out of scope
+  // Fails on Windows with `Permission denied`
+  // https://github.com/ignitionrobotics/ign-common/issues/148
+#ifndef _WIN32
   EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
   EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
+#endif
 }
 
 /////////////////////////////////////////////////
@@ -94,6 +98,10 @@ TEST_F(VideoEncoderTest, Exists)
   }
 
   // Check that temp files are removed when video goes out of scope
+  // Fails on Windows with `Permission denied`
+  // https://github.com/ignitionrobotics/ign-common/issues/148
+#ifndef _WIN32
   EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
   EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
+#endif
 }

--- a/av/src/VideoEncoder_TEST.cc
+++ b/av/src/VideoEncoder_TEST.cc
@@ -17,6 +17,7 @@
 
 #include "ignition/common/Console.hh"
 #include "ignition/common/VideoEncoder.hh"
+#include <ignition/utilities/ExtraTestMacros.hh>
 #include "test_config.h"
 #include "test/util.hh"
 
@@ -77,7 +78,7 @@ TEST_F(VideoEncoderTest, StartStop)
 }
 
 /////////////////////////////////////////////////
-TEST_F(VideoEncoderTest, Exists)
+TEST_F(VideoEncoderTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(Exists))
 {
   auto filePathMp4 = common::joinPaths(common::cwd(), "TMP_RECORDING.mp4");
   auto filePathMpg = common::joinPaths(common::cwd(), "TMP_RECORDING.mpg");
@@ -100,8 +101,6 @@ TEST_F(VideoEncoderTest, Exists)
   // Check that temp files are removed when video goes out of scope
   // Fails on Windows with `Permission denied`
   // https://github.com/ignitionrobotics/ign-common/issues/148
-#ifndef _WIN32
   EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
   EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
-#endif
 }

--- a/av/src/VideoEncoder_TEST.cc
+++ b/av/src/VideoEncoder_TEST.cc
@@ -15,6 +15,7 @@
 */
 #include <gtest/gtest.h>
 
+#include "ignition/common/Console.hh"
 #include "ignition/common/VideoEncoder.hh"
 #include "test_config.h"
 #include "test/util.hh"
@@ -22,58 +23,77 @@
 using namespace ignition;
 using namespace common;
 
-class VideoEncoderTest : public ignition::testing::AutoLogFixture { };
+class VideoEncoderTest : public ignition::testing::AutoLogFixture
+{
+  // Documentation inherited
+  protected: void SetUp() override
+  {
+    Console::SetVerbosity(4);
+  }
+};
 
 /////////////////////////////////////////////////
 TEST_F(VideoEncoderTest, StartStop)
 {
-  VideoEncoder video;
-  EXPECT_FALSE(video.IsEncoding());
-  EXPECT_STREQ(video.Format().c_str(), VIDEO_ENCODER_FORMAT_DEFAULT);
-  EXPECT_EQ(video.BitRate(), static_cast<unsigned int>(
-        VIDEO_ENCODER_BITRATE_DEFAULT));
-
   auto filePathMp4 = common::joinPaths(common::cwd(), "TMP_RECORDING.mp4");
   auto filePathMpg = common::joinPaths(common::cwd(), "TMP_RECORDING.mpg");
 
-  video.Start();
-  EXPECT_TRUE(video.IsEncoding());
-  EXPECT_TRUE(common::exists(filePathMp4));
-  EXPECT_EQ(video.BitRate(), 920000u);
+  {
+    VideoEncoder video;
+    EXPECT_FALSE(video.IsEncoding());
+    EXPECT_STREQ(video.Format().c_str(), VIDEO_ENCODER_FORMAT_DEFAULT);
+    EXPECT_EQ(video.BitRate(), static_cast<unsigned int>(
+          VIDEO_ENCODER_BITRATE_DEFAULT));
 
-  video.Stop();
-  EXPECT_FALSE(video.IsEncoding());
-  EXPECT_FALSE(common::exists(filePathMpg));
+    video.Start();
+    EXPECT_TRUE(video.IsEncoding());
+    EXPECT_TRUE(common::exists(filePathMp4)) << filePathMp4;
+    EXPECT_EQ(video.BitRate(), 920000u);
 
-  video.Start("mpg", "", 1024, 768);
-  EXPECT_TRUE(video.IsEncoding());
-  EXPECT_STREQ(video.Format().c_str(), "mpg");
-  EXPECT_TRUE(common::exists(filePathMpg));
+    video.Stop();
+    EXPECT_FALSE(video.IsEncoding());
+    EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
 
-  video.Start("mp4", "", 1024, 768);
-  EXPECT_TRUE(video.IsEncoding());
-  EXPECT_STREQ(video.Format().c_str(), "mpg");
+    video.Start("mpg", "", 1024, 768);
+    EXPECT_TRUE(video.IsEncoding());
+    EXPECT_STREQ(video.Format().c_str(), "mpg");
+    EXPECT_TRUE(common::exists(filePathMpg)) << filePathMpg;
 
-  video.Stop();
-  EXPECT_FALSE(video.IsEncoding());
+    video.Start("mp4", "", 1024, 768);
+    EXPECT_TRUE(video.IsEncoding());
+    EXPECT_STREQ(video.Format().c_str(), "mpg");
+
+    video.Stop();
+    EXPECT_FALSE(video.IsEncoding());
+  }
+
+  // Check that temp files are removed when video goes out of scope
+  EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
+  EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
 }
 
 /////////////////////////////////////////////////
 TEST_F(VideoEncoderTest, Exists)
 {
-  VideoEncoder video;
-  EXPECT_FALSE(video.IsEncoding());
-  EXPECT_STREQ(video.Format().c_str(), VIDEO_ENCODER_FORMAT_DEFAULT);
-
   auto filePathMp4 = common::joinPaths(common::cwd(), "TMP_RECORDING.mp4");
   auto filePathMpg = common::joinPaths(common::cwd(), "TMP_RECORDING.mpg");
 
-  EXPECT_FALSE(common::exists(filePathMp4));
-  EXPECT_FALSE(common::exists(filePathMpg));
+  {
+    VideoEncoder video;
+    EXPECT_FALSE(video.IsEncoding());
+    EXPECT_STREQ(video.Format().c_str(), VIDEO_ENCODER_FORMAT_DEFAULT);
 
-  video.Start();
-  EXPECT_TRUE(common::exists(filePathMp4));
+    EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
+    EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
 
-  video.Reset();
-  EXPECT_FALSE(common::exists(filePathMp4));
+    video.Start();
+    EXPECT_TRUE(common::exists(filePathMp4));
+
+    video.Reset();
+    EXPECT_FALSE(common::exists(filePathMp4));
+  }
+
+  // Check that temp files are removed when video goes out of scope
+  EXPECT_FALSE(common::exists(filePathMp4)) << filePathMp4;
+  EXPECT_FALSE(common::exists(filePathMpg)) << filePathMpg;
 }

--- a/graphics/src/CMakeLists.txt
+++ b/graphics/src/CMakeLists.txt
@@ -20,11 +20,7 @@ target_link_libraries(${graphics_target}
     FreeImage::FreeImage)
 
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
-  LIB_DEPS
-    ${graphics_target}
-    ignition-cmake${IGN_CMAKE_VER}::utilities
-)
-
+  LIB_DEPS ${graphics_target})
 
 if(USE_EXTERNAL_TINYXML2)
 

--- a/graphics/src/CMakeLists.txt
+++ b/graphics/src/CMakeLists.txt
@@ -20,7 +20,10 @@ target_link_libraries(${graphics_target}
     FreeImage::FreeImage)
 
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
-  LIB_DEPS ${graphics_target})
+  LIB_DEPS
+    ${graphics_target}
+    ignition-cmake${IGN_CMAKE_VER}::utilities
+)
 
 
 if(USE_EXTERNAL_TINYXML2)

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -207,7 +207,7 @@ bool create_new_file_hardlink(const std::string &_hardlink,
   return ::CreateHardLinkA(_hardlink.c_str(), _target.c_str(), nullptr) == TRUE;
 }
 
-#endif
+#endif  // _WIN32
 
 #include <fstream> // NOLINT
 #include "ignition/common/Console.hh"


### PR DESCRIPTION
An attempt at fixing https://github.com/ignitionrobotics/ign-common/issues/148.

The test changes are minimal, I recommend the view ignoring whitespace changes:

* Make test verbose
* Create `video` within a scope, so we can check that it deletes all temp files on destruction
* Output file paths in case the tests fail

The change that I hope will fix it is the use of `common::removeFile` instead of `std::remove`.