### PR TITLE
Collada transparency is opposite.

### DIFF
--- a/graphics/include/ignition/common/Material.hh
+++ b/graphics/include/ignition/common/Material.hh
@@ -151,10 +151,12 @@ namespace ignition
       public: math::Color Emissive() const;
 
       /// \brief Set the transparency percentage (0..1)
-      /// \param[in] _t The amount of transparency (0..1)
+      /// \param[in] _t The amount of transparency (0..1) where a value of 1
+      /// is fully transparent and 0 is not transparent.
       public: void SetTransparency(double _t);
 
       /// \brief Get the transparency percentage (0..1)
+      /// A value of 1 is fully transparent and 0 is not transparent.
       /// \return The transparency percentage
       public: double Transparency() const;
 

--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -723,7 +723,9 @@ void ColladaExporterPrivate::ExportEffects(
     specularXml->LinkEndChild(colorXml);
 
     // transparency
-    double transp = material->Transparency();
+    // In Collada, a transparency value of 1 is not transparent and 0 is
+    // fully transparent.
+    double transp = 1.0 - material->Transparency();
 
     tinyxml2::XMLElement *transparencyXml =
       _libraryEffectsXml->GetDocument()->NewElement("transparency");


### PR DESCRIPTION
Collada considers an object to be transparent when the `<transparent>` value is 0 instead of 1.
This resolves: https://github.com/ignitionrobotics/ign-gazebo/pull/474#discussion_r547456437

Signed-off-by: Nate Koenig <nate@openrobotics.org>