### PR TITLE
Added C language bindings for SystemPaths::FindFile and Console::SetVerbosity

### DIFF
--- a/src/ign.cc
+++ b/src/ign.cc
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <cstring>
+
+#include <ignition/common/Console.hh>
+#include <ignition/common/SystemPaths.hh>
+
+#include "ignition/common/config.hh"
+#include "ign.hh"
+
+//////////////////////////////////////////////////
+extern "C" IGNITION_COMMON_VISIBLE char* ignitionCommonVersion()
+{
+  return strdup(IGNITION_COMMON_VERSION_FULL);
+}
+
+//////////////////////////////////////////////////
+extern "C" IGNITION_COMMON_VISIBLE void cmdVerbosity(
+  const char* _verbosity)
+{
+  ignition::common::Console::SetVerbosity(std::atoi(_verbosity));
+}
+
+//////////////////////////////////////////////////
+extern "C" IGNITION_COMMON_VISIBLE char* findFileInPathEnv(
+  const char* _fileName, const char* _envName, const char* _defaultPath)
+{
+  ignition::common::SystemPaths paths;
+  paths.SetFilePathEnv(_envName);
+  if (strlen(_defaultPath) > 0)
+    paths.AddFilePaths(_defaultPath);
+
+  const auto foundPath = paths.FindFile(_fileName, false);
+  return strdup(ignition::common::copyFromUnixPath(foundPath).c_str());
+}

--- a/src/ign.hh
+++ b/src/ign.hh
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef IGNITION_COMMON_IGN_HH_
+#define IGNITION_COMMON_IGN_HH_
+
+#include "ignition/common/Export.hh"
+
+/// \brief External hook to read the library version.
+/// \return C-string representing the version. Ex.: 0.1.2
+extern "C" IGNITION_COMMON_VISIBLE char* ignitionCommonVersion();
+
+/// \brief Set console verbosity of the other commands in this library.
+/// \param[in] _verbosity 0 to 4
+extern "C" IGNITION_COMMON_VISIBLE void cmdVerbosity(
+  const char* _verbosity);
+
+/// \brief Set console verbosity of the other commands in this library.
+/// \param[in] _fileName Name of the searched file.
+/// \param[in] _envName Name of the environment variable that holds additional
+/// search paths. The content of the variable is treated as a colon/semicolon
+/// separated list.
+/// \param[in] _defaultPath Other directories to search (searched after those
+/// extracted from the environment variable). A colon/semicolon separated list.
+/// \return Path to the found existing file, or empty string if the file could
+/// not be found. The path will use native separators.
+extern "C" IGNITION_COMMON_VISIBLE char* findFileInPathEnv(
+  const char* _fileName, const char* _envName, const char* _defaultPath = "");
+
+#endif

--- a/src/ign_TEST.cc
+++ b/src/ign_TEST.cc
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+#include <cstdio>
+#include <cstdlib>
+
+#include <string>
+#include <ign.hh>
+#include <ignition/common/Console.hh>
+#include <ignition/common/Util.hh>
+
+using namespace ignition::common;
+
+/////////////////////////////////////////////////
+TEST(CBindings, Verbosity)
+{
+  cmdVerbosity("4");
+  EXPECT_EQ(4, Console::Verbosity());
+
+  cmdVerbosity("3");
+  EXPECT_EQ(3, Console::Verbosity());
+
+  cmdVerbosity("2");
+  EXPECT_EQ(2, Console::Verbosity());
+
+  cmdVerbosity("1");
+  EXPECT_EQ(1, Console::Verbosity());
+}
+
+/////////////////////////////////////////////////
+TEST(CBindings, FindFile)
+{
+  const auto kEnvName = "IGN_TEST_PATH";
+  const auto thisFilePath = __FILE__;
+  const auto thisFile = ignition::common::basename(thisFilePath);
+  const auto thisDir = parentPath(thisFilePath);
+  const auto projectDir = parentPath(thisDir);
+
+  setenv(kEnvName, thisDir);
+  auto path = findFileInPathEnv(thisFile.c_str(), kEnvName);
+  EXPECT_STREQ(thisFilePath, path);
+
+  setenv(kEnvName, thisDir + SystemPaths::Delimiter() + "foo");
+  path = findFileInPathEnv(thisFile.c_str(), kEnvName);
+  EXPECT_STREQ(thisFilePath, path);
+
+  setenv(kEnvName, std::string("foo") + SystemPaths::Delimiter() + thisDir);
+  path = findFileInPathEnv(thisFile.c_str(), kEnvName);
+  EXPECT_STREQ(thisFilePath, path);
+
+  setenv(kEnvName, "foo");
+  path = findFileInPathEnv(thisFile.c_str(), kEnvName, thisDir.c_str());
+  EXPECT_STREQ(thisFilePath, path);
+
+  setenv(kEnvName, thisDir);
+  path = findFileInPathEnv(thisFile.c_str(), kEnvName, "foo");
+  EXPECT_STREQ(thisFilePath, path);
+
+  // empty search path means the file should not be found
+  setenv(kEnvName, "");
+  path = findFileInPathEnv(thisFile.c_str(), kEnvName);
+  EXPECT_STREQ("", path);
+
+  const auto thisCMakeLists = joinPaths(thisDir, "CMakeLists.txt");
+  const auto projectCMakeLists = joinPaths(projectDir, "CMakeLists.txt");
+  ASSERT_TRUE(exists(thisCMakeLists));
+  ASSERT_TRUE(exists(projectCMakeLists));
+
+  // paths from environment take precedence over default paths
+  setenv(kEnvName, thisDir);
+  path = findFileInPathEnv("CMakeLists.txt", kEnvName, projectDir.c_str());
+  EXPECT_STREQ(thisCMakeLists.c_str(), path);
+
+  // paths from environment are searched left to right
+  setenv(kEnvName, thisDir + SystemPaths::Delimiter() + projectDir);
+  path = findFileInPathEnv("CMakeLists.txt", kEnvName);
+  EXPECT_STREQ(thisCMakeLists.c_str(), path);
+}
+
+/////////////////////////////////////////////////
+int main(int _argc, char **_argv)
+{
+  ::testing::InitGoogleTest(&_argc, _argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# New feature

Helps closing https://github.com/ignitionrobotics/ign-launch/issues/92 .

## Summary
The functionality in `SystemPaths` is already quite mature, so I think it makes sense to expose it to other languages via C bindings. This will help code re-use in other parts of Ignition libraries, e.g. in Ruby scripts.

## Test it
Unit tests were added. Otherwise, you can test it e.g. from Ruby by importing the common library and calling some of the added functions.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**