### PR TITLE
Install the profiler in a version-safe manner

### DIFF
--- a/profiler/src/CMakeLists.txt
+++ b/profiler/src/CMakeLists.txt
@@ -88,15 +88,17 @@ if(TARGET UNIT_Profiler_Remotery_TEST)
 endif()
 
 if(IGN_PROFILER_REMOTERY)
+  set(IGN_PROFILER_SCRIPT_PATH ${CMAKE_INSTALL_LIBDIR}/ignition/ignition-common${PROJECT_VERSION_MAJOR})
   set(IGN_PROFILER_VIS_PATH ${IGN_DATA_INSTALL_DIR}/profiler_vis)
 
   configure_file(Remotery/ign_remotery_vis.in
-    ${CMAKE_CURRENT_BINARY_DIR}/ign_remotery_vis)
+    ${CMAKE_CURRENT_BINARY_DIR}/ign_remotery_vis
+    @ONLY)
 
   install(PROGRAMS
     ${CMAKE_CURRENT_BINARY_DIR}/ign_remotery_vis
-    DESTINATION bin)
+    DESTINATION ${IGN_PROFILER_SCRIPT_PATH})
 
   install(DIRECTORY Remotery/vis/
-          DESTINATION ${IGN_DATA_INSTALL_DIR}/profiler_vis)
+          DESTINATION ${IGN_PROFILER_VIS_PATH})
 endif()

--- a/profiler/src/Remotery/ign_remotery_vis.in
+++ b/profiler/src/Remotery/ign_remotery_vis.in
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
 
-VIS_PATH=@CMAKE_INSTALL_PREFIX@/@IGN_PROFILER_VIS_PATH@/index.html
+SCRIPT_PATH=@IGN_PROFILER_SCRIPT_PATH@/ign_remotery_vis
+VIS_PATH=@IGN_PROFILER_VIS_PATH@/index.html
 
+# Get the full path to this script
+SCRIPT=`realpath $0`
+
+# Strip the known script path off the end of the full path
+INSTALL_ROOT=${SCRIPT%${SCRIPT_PATH}}
+
+# Append the relative vis path
+VIS_PATH=$INSTALL_ROOT/$VIS_PATH
+
+# Open with a system web browser
 if [ -x "$(command -v xdg-open)" ]; then
   xdg-open $VIS_PATH
 elif [ -x "$(command -v open)" ]; then

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -86,7 +86,7 @@ From terminal 2, open the visualizer using one of the following commands
 
 ```{.sh}
 # Use a launcher script (Linux and macOS)
-ign_remotery_vis
+/usr/lib/ignition/ignition-common4/ign_remotery_vis
 
 # Use the source path (Linux)
 # Substitute the path to your ign-common source checkout

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -85,8 +85,11 @@ From terminal 1:
 From terminal 2, open the visualizer using one of the following commands
 
 ```{.sh}
-# Use a launcher script (Linux and macOS)
-/usr/lib/ignition/ignition-common4/ign_remotery_vis
+# Find the launcher script and use it (Linux and macOS)
+find /usr | grep ign_remotery_vis
+...
+
+/usr/<path_to>/ign_remotery_vis
 
 # Use the source path (Linux)
 # Substitute the path to your ign-common source checkout


### PR DESCRIPTION
# Bug Report

Fixes issue #167
Fixes issue #82 

## Summary

This makes the profiler script get installed in a versioned subdirectory, which will enable side-by-side installs.

In this case, it follows along with our CLI executable strategy and installs to `install/lib/ignition/ignition-common4/ign_remotery_vis`

This additionally makes the profiler script relocatable by removing absolute paths from the CMake configuration process.

## Checklist
- [x] Signed all commits for DCO
- [x] ~Added tests~
- [x] Updated documentation (as needed)
- [x] ~Updated migration guide (as needed)~
- [x] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
