### PR TITLE
Prevent console spam when exporting a mesh with multiple texture coordinates

### DIFF
--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -333,7 +333,7 @@ void ColladaExporterPrivate::ExportGeometrySource(
     ignition::math::Vector2d inTexCoord;
     for (unsigned int i = 0; i < count; ++i)
     {
-      inTexCoord = _subMesh->TexCoord(i);
+      inTexCoord = _subMesh->TexCoordBySet(i, 0);
       fillData << inTexCoord.X() << " " << 1-inTexCoord.Y() << " ";
     }
   }
@@ -422,7 +422,7 @@ void ColladaExporterPrivate::ExportGeometries(
 
     this->ExportGeometrySource(subMesh.get(), meshXml, POSITION, meshId);
     this->ExportGeometrySource(subMesh.get(), meshXml, NORMAL, meshId);
-    if (subMesh->TexCoordCount() != 0)
+    if (subMesh->TexCoordCountBySet(0) != 0)
     {
       this->ExportGeometrySource(subMesh.get(), meshXml, UVMAP, meshId);
     }
@@ -468,7 +468,7 @@ void ColladaExporterPrivate::ExportGeometries(
     snprintf(attributeValue, sizeof(attributeValue), "#%s-Normals", meshId);
     inputXml->SetAttribute("source", attributeValue);
 
-    if (subMesh->TexCoordCount() != 0)
+    if (subMesh->TexCoordCountBySet(0) != 0)
     {
       inputXml = _libraryGeometriesXml->GetDocument()->NewElement("input");
       trianglesXml->LinkEndChild(inputXml);
@@ -482,7 +482,7 @@ void ColladaExporterPrivate::ExportGeometries(
     for (unsigned int j = 0; j < indexCount; ++j)
     {
       fillData << subMesh->Index(j) << " " << subMesh->Index(j) << " ";
-      if (subMesh->TexCoordCount() != 0)
+      if (subMesh->TexCoordCountBySet(0) != 0)
       {
         fillData << subMesh->Index(j) << " ";
       }


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# Bug Report

## Summary

Using the ColladaExporter can flood the console with warnings like the following:
```
[Wrn] [SubMesh.cc:478] Multiple texture coordinate sets exist in submesh: WallPlaster. Checking first set with index: 0
```

This happens when a mesh has multiple texture coordinates. The ColladaExporter can prevent this by using the SubMesh function calls that specify which texture coordinate set to use.

## Checklist
- [X] Signed all commits for DCO
- [X] `codecheck` passed
- [X] All tests passed
- [X] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**