### PR TITLE
Restore support for model:// URIs

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -13,7 +13,7 @@ release will remove the deprecated code.
    `PixelFormatType` located in `graphics/include/ignition/common/Image.hh`.
 
 1. URI parsing has updated to follow the specification more closely when
-   `URI::HasAuthority` is set to true. Changes include:
+   `URI::Authority` is set. Changes include:
     * An empty URI Path is valid.
     * Double forward slashes, `//`, are valid in a URI Path.
     * A URI Query does not require a `key=value` format. For example

--- a/Migration.md
+++ b/Migration.md
@@ -14,6 +14,21 @@ release will remove the deprecated code.
 
 1. URI parsing has updated to follow the specification more closely. Changes
    include:
+    * Deprecated `URI::Path()`, which is now divided into `URI::Authority` and
+    `URI::PathSegments`. Update your code to set / get both of them.
+     For example:
+
+        ```
+        uri.Path() = "localhost:8080/path";
+        ```
+
+        becomes
+
+        ```
+        uri.Authority() = "//localhost:8080";
+        uri.Path() = "/path";
+        ```
+
     * An empty URI Path is valid.
     * Double forward slashes, `//`, are valid in a URI Path.
     * A URI Query does not require a `key=value` format. For example
@@ -21,6 +36,8 @@ release will remove the deprecated code.
     * A URI authority is optional. If present, then a URI authority begins
     with two forward slashes and immediately follows the URI scheme. A host
     must be present if an authority is present and the scheme != 'file'.
+    * Trailing `/` after the authority is part of the path segments and is no
+    longer stripped.
 
 ## Ignition Common 2.X to 3.X
 

--- a/Migration.md
+++ b/Migration.md
@@ -12,23 +12,8 @@ release will remove the deprecated code.
 1. Corrected `BAYER_RGGR8` to `BAYER_BGGR8` in `PixelFormatName` and
    `PixelFormatType` located in `graphics/include/ignition/common/Image.hh`.
 
-1. URI parsing has updated to follow the specification more closely. Changes
-   include:
-    * Deprecated `URI::Path()`, which is now divided into `URI::Authority` and
-    `URI::PathSegments`. Update your code to set / get both of them.
-     For example:
-
-        ```
-        uri.Path() = "localhost:8080/path";
-        ```
-
-        becomes
-
-        ```
-        uri.Authority() = "//localhost:8080";
-        uri.Path() = "/path";
-        ```
-
+1. URI parsing has updated to follow the specification more closely when
+   `URI::HasAuthority` is set to true. Changes include:
     * An empty URI Path is valid.
     * Double forward slashes, `//`, are valid in a URI Path.
     * A URI Query does not require a `key=value` format. For example
@@ -36,8 +21,6 @@ release will remove the deprecated code.
     * A URI authority is optional. If present, then a URI authority begins
     with two forward slashes and immediately follows the URI scheme. A host
     must be present if an authority is present and the scheme != 'file'.
-    * Trailing `/` after the authority is part of the path segments and is no
-    longer stripped.
 
 ## Ignition Common 2.X to 3.X
 

--- a/include/ignition/common/SystemPaths.hh
+++ b/include/ignition/common/SystemPaths.hh
@@ -71,9 +71,12 @@ namespace ignition
       /// \param[in] _uri the uniform resource identifier
       /// \return Returns full path name to file with platform-specific
       /// directory separators, or an empty string if URI couldn't be found.
+      /// \sa FindFileURI(const ignition::common::URI &_uri)
       public: std::string FindFileURI(const std::string &_uri) const;
 
-      /// \brief Find a file or path using a URI
+      /// \brief Find a file or path using a URI.
+      /// If URI is not an absolute path, the URI's "Host / PathSegments"
+      /// will be matched against all added paths and environment variables.
       /// \param[in] _uri the uniform resource identifier
       /// \return Returns full path name to file with platform-specific
       /// directory separators, or an empty string if URI couldn't be found.

--- a/include/ignition/common/SystemPaths.hh
+++ b/include/ignition/common/SystemPaths.hh
@@ -75,8 +75,9 @@ namespace ignition
       public: std::string FindFileURI(const std::string &_uri) const;
 
       /// \brief Find a file or path using a URI.
-      /// If URI is not an absolute path, the URI's "Host / PathSegments"
-      /// will be matched against all added paths and environment variables.
+      /// If URI is not an absolute path, the URI's path will be matched against
+      /// all added paths and environment variables (including URI authority as
+      /// needed).
       /// \param[in] _uri the uniform resource identifier
       /// \return Returns full path name to file with platform-specific
       /// directory separators, or an empty string if URI couldn't be found.
@@ -90,10 +91,12 @@ namespace ignition
       /// \param[in] _filename Name of the file to find.
       /// \param[in] _searchLocalPath True to search in the current working
       /// directory.
+      /// \param[in] _verbose False to omit console messages.
       /// \return Returns full path name to file with platform-specific
       /// directory separators, or empty string on error.
       public: std::string FindFile(const std::string &_filename,
-                                   const bool _searchLocalPath = true) const;
+                                   const bool _searchLocalPath = true,
+                                   const bool _verbose = true) const;
 
       /// \brief Find a shared library by name in the plugin paths
       ///

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -410,7 +410,8 @@ namespace ignition
 
       /// \brief Default constructor
       /// \param[in] _hasAuthority False if the URI doesn't have an authority.
-      /// Defaults to false.
+      /// Defaults to false. If true, an authority will be created and will be
+      /// empty.
       public: explicit URI(const std::string &_str,
           bool _hasAuthority = false);
 
@@ -444,6 +445,9 @@ namespace ignition
       public: void SetAuthority(const URIAuthority &_authority);
 
       /// \brief Get a copy of the URI's authority.
+      /// If the authority has no value (as opposed to being empty), it means
+      /// that it isn't present, and the authority value may be contained in
+      /// the path instead.
       /// \return The authority
       public: std::optional<URIAuthority> Authority() const;
 
@@ -491,6 +495,10 @@ namespace ignition
       public: static bool Valid(const std::string &_str);
 
       /// \brief Parse a string as URI.
+      /// If there's no authority (i.e. `Authority().has_value() == false`),
+      /// authority information will be contained within the path.
+      /// In order to populate the `Authority`, either set `hasAuthority` to
+      /// true on the constructor or set an empty authority before parsing.
       /// \param[in] _str A string.
       /// \return True if the string can be parsed as a URI.
       public: bool Parse(const std::string &_str);

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -148,7 +148,15 @@ namespace ignition
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
 
-    /// \brief The path component of a URI
+    /// \brief A URI path contains a sequence of segments separated by `/`.
+    /// The path may be empty in a valid URI.
+    /// When an authority is present, the path must start with a `/`.
+    ///
+    /// In the following URI:
+    ///
+    /// scheme://authority.com/seg1/seg2?query
+    ///
+    /// The path is `/seg1/seg2`
     class IGNITION_COMMON_VISIBLE URIPath
     {
       /// \brief Constructor
@@ -422,11 +430,25 @@ namespace ignition
 
       /// \brief Get a mutable version of the path component
       /// \return A reference to the path
-      public: URIPath &Path();
+      /// \deprecated Use `PathSegments()`, the path doesn't contain the
+      /// authority anymore.
+      public: URIPath IGN_DEPRECATED(4.0) &Path();
 
       /// \brief Get a const reference of the path component.
       /// \return A const reference of the path.
-      public: const URIPath &Path() const;
+      /// \deprecated Use `PathSegments()`, the path doesn't contain the
+      /// authority anymore.
+      public: const URIPath IGN_DEPRECATED(4.0) &Path() const;
+
+      /// \brief Get a mutable version of the path component.
+      /// The path doesn't contain the authority.
+      /// \return A reference to the path
+      public: URIPath &PathSegments();
+
+      /// \brief Get a const reference of the path component.
+      /// The path doesn't contain the authority.
+      /// \return A const reference of the path.
+      public: const URIPath &PathSegments() const;
 
       /// \brief Get a mutable version of the query component
       /// \return A reference to the query

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -52,6 +52,13 @@ namespace ignition
     /// authority. For example, `file://abs/path` will result in a host
     /// value of `abs` and the URI path will be `/path`. You can specify
     /// a relative path using `file:abs/path`.
+    ///
+    /// URIs that are set not to have an authority
+    /// (i.e. `HasAuthority() == false`) preserve the legacy behaviour, which
+    /// is:
+    /// * `file:/abs/path` has the path `/abs/path`
+    /// * `file://abs/path` has the path `abs/path`
+    /// * `file:///abs/path` has the path `/abs/path`
     class IGNITION_COMMON_VISIBLE URIAuthority
     {
       /// \brief Constructor
@@ -210,6 +217,16 @@ namespace ignition
       /// URI-encoded to %2F. The path is also set to absolute if it is empty
       /// and a Windows drive specifier (e.g. 'C:') is pushed to it.
       public: void PushBack(const std::string &_part);
+
+      /// \brief Remove the part that's in the front of this path and return it.
+      /// \return Popped part.
+      /// Returns empty string if path doesn't have parts to be popped.
+      public: std::string PopFront();
+
+      /// \brief Remove the part that's in the back of this path and return it.
+      /// \return Popped part.
+      /// Returns empty string if path doesn't have parts to be popped.
+      public: std::string PopBack();
 
       /// \brief Compound assignment operator.
       /// \param[in] _part A new path to append.
@@ -391,9 +408,11 @@ namespace ignition
       /// \brief Default constructor
       public: URI();
 
-      /// \brief Construct a URI object from a string.
-      /// \param[in] _str A string.
-      public: explicit URI(const std::string &_str);
+      /// \brief Default constructor
+      /// \param[in] _hasAuthority False if the URI doesn't have an authority.
+      /// Defaults to false.
+      public: explicit URI(const std::string &_str,
+          bool _hasAuthority = false);
 
       /// \brief Copy constructor
       /// \param[in] _uri Another URI.
@@ -421,34 +440,37 @@ namespace ignition
       public: void SetScheme(const std::string &_scheme);
 
       /// \brief Get a mutable version of the URI's authority.
+      /// This method shouldn't be used if `HasAuthority` is false.
       /// \return The authority
       public: URIAuthority &Authority();
 
       /// \brief Get a const reference of the URI's authority.
+      /// This method shouldn't be used if `HasAuthority` is false.
       /// \return The authority
       public: const URIAuthority &Authority() const;
 
       /// \brief Get a mutable version of the path component
       /// \return A reference to the path
-      /// \deprecated Use `PathSegments()`, the path doesn't contain the
-      /// authority anymore.
-      public: URIPath IGN_DEPRECATED(4.0) &Path();
+      public: URIPath &Path();
 
       /// \brief Get a const reference of the path component.
       /// \return A const reference of the path.
-      /// \deprecated Use `PathSegments()`, the path doesn't contain the
-      /// authority anymore.
-      public: const URIPath IGN_DEPRECATED(4.0) &Path() const;
+      public: const URIPath &Path() const;
 
-      /// \brief Get a mutable version of the path component.
-      /// The path doesn't contain the authority.
-      /// \return A reference to the path
-      public: URIPath &PathSegments();
+      /// \brief Set whether the URI has an authority. When false, whatever
+      /// would be part of the authority becomes the first part of the path.
+      /// Defaults to false, which is the legacy behaviour.
+      /// If false, the `Authority` functions shouldn't be used.
+      /// \param[in] _hasAuthority False to omit the authority.
+      /// \sa HasAuthority
+      public: void SetHasAuthority(bool _hasAuthority);
 
-      /// \brief Get a const reference of the path component.
-      /// The path doesn't contain the authority.
-      /// \return A const reference of the path.
-      public: const URIPath &PathSegments() const;
+      /// \brief Get whether the URI has an authority.
+      /// Defaults to false, which is the legacy behaviour.
+      /// If false, the `Authority` functions shouldn't be used.
+      /// \return False if there's no authority.
+      /// \sa SetHasAuthority
+      public: bool HasAuthority() const;
 
       /// \brief Get a mutable version of the query component
       /// \return A reference to the query

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -54,7 +54,7 @@ namespace ignition
     /// a relative path using `file:abs/path`.
     ///
     /// URIs that are set not to have an authority
-    /// (i.e. `HasAuthority() == false`) preserve the legacy behaviour, which
+    /// (i.e. `Authority() == false`) preserve the legacy behaviour, which
     /// is:
     /// * `file:/abs/path` has the path `/abs/path`
     /// * `file://abs/path` has the path `abs/path`
@@ -439,15 +439,13 @@ namespace ignition
       /// \param[in] _scheme New scheme.
       public: void SetScheme(const std::string &_scheme);
 
-      /// \brief Get a mutable version of the URI's authority.
-      /// This method shouldn't be used if `HasAuthority` is false.
+      /// \brief Set the URI's authority.
       /// \return The authority
-      public: URIAuthority &Authority();
+      public: void SetAuthority(const URIAuthority &_authority);
 
-      /// \brief Get a const reference of the URI's authority.
-      /// This method shouldn't be used if `HasAuthority` is false.
+      /// \brief Get a copy of the URI's authority.
       /// \return The authority
-      public: const URIAuthority &Authority() const;
+      public: std::optional<URIAuthority> Authority() const;
 
       /// \brief Get a mutable version of the path component
       /// \return A reference to the path
@@ -456,21 +454,6 @@ namespace ignition
       /// \brief Get a const reference of the path component.
       /// \return A const reference of the path.
       public: const URIPath &Path() const;
-
-      /// \brief Set whether the URI has an authority. When false, whatever
-      /// would be part of the authority becomes the first part of the path.
-      /// Defaults to false, which is the legacy behaviour.
-      /// If false, the `Authority` functions shouldn't be used.
-      /// \param[in] _hasAuthority False to omit the authority.
-      /// \sa HasAuthority
-      public: void SetHasAuthority(bool _hasAuthority);
-
-      /// \brief Get whether the URI has an authority.
-      /// Defaults to false, which is the legacy behaviour.
-      /// If false, the `Authority` functions shouldn't be used.
-      /// \return False if there's no authority.
-      /// \sa SetHasAuthority
-      public: bool HasAuthority() const;
 
       /// \brief Get a mutable version of the query component
       /// \return A reference to the query

--- a/src/SystemPaths.cc
+++ b/src/SystemPaths.cc
@@ -314,10 +314,10 @@ std::string SystemPaths::FindFileURI(const ignition::common::URI &_uri) const
 {
   std::string prefix = _uri.Scheme();
   std::string suffix;
-  if (_uri.HasAuthority())
+  if (_uri.Authority())
   {
     // Strip //
-    suffix = _uri.Authority().Str().substr(2) + _uri.Path().Str();
+    suffix = (*_uri.Authority()).Str().substr(2) + _uri.Path().Str();
   }
   else
   {

--- a/src/SystemPaths.cc
+++ b/src/SystemPaths.cc
@@ -313,7 +313,8 @@ std::string SystemPaths::FindFileURI(const std::string &_uri) const
 std::string SystemPaths::FindFileURI(const ignition::common::URI &_uri) const
 {
   std::string prefix = _uri.Scheme();
-  std::string suffix = _uri.Path().Str() + _uri.Query().Str();
+  std::string suffix = _uri.Authority().Host() + _uri.PathSegments().Str() +
+      _uri.Query().Str();
   std::string filename;
 
   if (prefix == "file")

--- a/src/SystemPaths.cc
+++ b/src/SystemPaths.cc
@@ -317,7 +317,7 @@ std::string SystemPaths::FindFileURI(const ignition::common::URI &_uri) const
   if (_uri.Authority())
   {
     // Strip //
-    suffix = (*_uri.Authority()).Str().substr(2) + _uri.Path().Str();
+    suffix = _uri.Authority()->Str().substr(2) + _uri.Path().Str();
   }
   else
   {

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -234,7 +234,7 @@ TEST_F(SystemPathsFixture, FindFileURI)
   auto osrfCb = [dir2](const ignition::common::URI &_uri)
   {
     return _uri.Scheme() == "osrf" ?
-           ignition::common::joinPaths(dir2, _uri.PathSegments().Str()) : "";
+           ignition::common::joinPaths(dir2, _uri.Authority().Host()) : "";
   };
   auto robot2Cb = [dir2](const ignition::common::URI &_uri)
   {
@@ -266,7 +266,7 @@ TEST_F(SystemPathsFixture, FindFileURI)
   // second handler for the same protocol is available
   sp.AddFindFileURICallback(robot2Cb);
   EXPECT_EQ(file1, sp.FindFileURI("robot://test_f1"));
-  EXPECT_EQ(file2, sp.FindFileURI("osrf:test_f2"));
+  EXPECT_EQ(file2, sp.FindFileURI("osrf://test_f2"));
 
   // URI + env var
   common::setenv(kFilePath, dir1);

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -126,7 +126,7 @@ TEST_F(SystemPathsFixture, FileSystemPaths)
   filePaths.push_back("test_dir1");
   common::setenv(kFilePath, SystemPathsJoin(filePaths));
   paths.SetFilePathEnv(kFilePath);
-  EXPECT_EQ(file1, paths.FindFile("test_f1")) << paths.FindFile("test_f1");
+  EXPECT_EQ(file1, paths.FindFile("test_f1"));
   EXPECT_EQ(file1, paths.FindFile("model://test_f1"));
 }
 
@@ -206,7 +206,7 @@ TEST_F(SystemPathsFixture, FindFileURI)
           this->filesystemRoot);
 
   EXPECT_EQ("", sp.FindFileURI("file://no_such_file"));
-  EXPECT_EQ(file1, sp.FindFileURI("file://test_dir1/test_f1"));
+  EXPECT_EQ(file1, sp.FindFileURI("file:test_dir1/test_f1"));
   EXPECT_EQ(file1, sp.FindFileURI("file://" +
                                   ignition::common::copyToUnixPath(file1)));
   EXPECT_EQ("", sp.FindFileURI("osrf://unknown.protocol"));
@@ -234,12 +234,13 @@ TEST_F(SystemPathsFixture, FindFileURI)
   auto osrfCb = [dir2](const ignition::common::URI &_uri)
   {
     return _uri.Scheme() == "osrf" ?
-           ignition::common::joinPaths(dir2, _uri.Authority().Host()) : "";
+           ignition::common::joinPaths(dir2, ignition::common::copyFromUnixPath(
+           _uri.Path().Str())) : "";
   };
   auto robot2Cb = [dir2](const ignition::common::URI &_uri)
   {
     return _uri.Scheme() == "robot" ?
-           ignition::common::joinPaths(dir2, _uri.PathSegments().Str()) : "";
+           ignition::common::joinPaths(dir2, _uri.Path().Str()) : "";
   };
 
   EXPECT_EQ("", sp.FindFileURI("robot://test_f1"));
@@ -317,7 +318,8 @@ TEST_F(SystemPathsFixture, FindFile)
   EXPECT_EQ("", sp.FindFile(this->filesystemRoot + "no_such_file"));
   EXPECT_EQ("", sp.FindFile("no_such_file"));
   EXPECT_EQ(file1, sp.FindFile(common::joinPaths("test_dir1", "test_f1")));
-  EXPECT_EQ(file1, sp.FindFile("file://test_dir1/test_f1"));
+
+  EXPECT_EQ(file1, sp.FindFile("file:test_dir1/test_f1"));
 
   // Existing absolute paths
 #ifndef _WIN32

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -127,7 +127,7 @@ TEST_F(SystemPathsFixture, FileSystemPaths)
   common::setenv(kFilePath, SystemPathsJoin(filePaths));
   paths.SetFilePathEnv(kFilePath);
   EXPECT_EQ(file1, paths.FindFile("test_f1")) << paths.FindFile("test_f1");
-  EXPECT_EQ(file1, paths.FindFile("model:test_f1"));
+  EXPECT_EQ(file1, paths.FindFile("model://test_f1"));
 }
 
 /////////////////////////////////////////////////
@@ -206,7 +206,7 @@ TEST_F(SystemPathsFixture, FindFileURI)
           this->filesystemRoot);
 
   EXPECT_EQ("", sp.FindFileURI("file://no_such_file"));
-  EXPECT_EQ(file1, sp.FindFileURI("file:test_dir1/test_f1"));
+  EXPECT_EQ(file1, sp.FindFileURI("file://test_dir1/test_f1"));
   EXPECT_EQ(file1, sp.FindFileURI("file://" +
                                   ignition::common::copyToUnixPath(file1)));
   EXPECT_EQ("", sp.FindFileURI("osrf://unknown.protocol"));
@@ -234,16 +234,16 @@ TEST_F(SystemPathsFixture, FindFileURI)
   auto osrfCb = [dir2](const ignition::common::URI &_uri)
   {
     return _uri.Scheme() == "osrf" ?
-           ignition::common::joinPaths(dir2, _uri.Path().Str()) : "";
+           ignition::common::joinPaths(dir2, _uri.PathSegments().Str()) : "";
   };
   auto robot2Cb = [dir2](const ignition::common::URI &_uri)
   {
     return _uri.Scheme() == "robot" ?
-           ignition::common::joinPaths(dir2, _uri.Path().Str()) : "";
+           ignition::common::joinPaths(dir2, _uri.PathSegments().Str()) : "";
   };
 
   EXPECT_EQ("", sp.FindFileURI("robot://test_f1"));
-  EXPECT_EQ("", sp.FindFileURI("osrf:test_f2"));
+  EXPECT_EQ("", sp.FindFileURI("osrf://test_f2"));
 
   // We still want to test the deprecated function until it is removed.
 #ifndef _WIN32
@@ -256,11 +256,11 @@ TEST_F(SystemPathsFixture, FindFileURI)
 #endif
 
   EXPECT_EQ(file1, sp.FindFileURI("robot://test_f1"));
-  EXPECT_EQ("", sp.FindFileURI("osrf:test_f2"));
+  EXPECT_EQ("", sp.FindFileURI("osrf://test_f2"));
 
   sp.AddFindFileURICallback(osrfCb);
   EXPECT_EQ(file1, sp.FindFileURI("robot://test_f1"));
-  EXPECT_EQ(file2, sp.FindFileURI("osrf:test_f2"));
+  EXPECT_EQ(file2, sp.FindFileURI("osrf://test_f2"));
 
   // Test that th CB from SetFindFileURICallback is called first even when a
   // second handler for the same protocol is available
@@ -272,15 +272,15 @@ TEST_F(SystemPathsFixture, FindFileURI)
   common::setenv(kFilePath, dir1);
   sp.SetFilePathEnv(kFilePath);
   EXPECT_EQ(kFilePath, sp.FilePathEnv());
-  EXPECT_EQ(file1, sp.FindFileURI("anything:test_f1"));
-  EXPECT_NE(file2, sp.FindFileURI("anything:test_f2"));
+  EXPECT_EQ(file1, sp.FindFileURI("anything://test_f1"));
+  EXPECT_NE(file2, sp.FindFileURI("anything://test_f2"));
 
   std::string newEnv{"IGN_NEW_FILE_PATH"};
   common::setenv(newEnv, dir2);
   sp.SetFilePathEnv(newEnv);
   EXPECT_EQ(newEnv, sp.FilePathEnv());
-  EXPECT_NE(file1, sp.FindFileURI("anything:test_f1"));
-  EXPECT_EQ(file2, sp.FindFileURI("anything:test_f2"));
+  EXPECT_NE(file1, sp.FindFileURI("anything://test_f1"));
+  EXPECT_EQ(file2, sp.FindFileURI("anything://test_f2"));
 }
 
 //////////////////////////////////////////////////
@@ -317,7 +317,7 @@ TEST_F(SystemPathsFixture, FindFile)
   EXPECT_EQ("", sp.FindFile(this->filesystemRoot + "no_such_file"));
   EXPECT_EQ("", sp.FindFile("no_such_file"));
   EXPECT_EQ(file1, sp.FindFile(common::joinPaths("test_dir1", "test_f1")));
-  EXPECT_EQ(file1, sp.FindFile("file:test_dir1/test_f1"));
+  EXPECT_EQ(file1, sp.FindFile("file://test_dir1/test_f1"));
 
   // Existing absolute paths
 #ifndef _WIN32

--- a/src/URI.cc
+++ b/src/URI.cc
@@ -194,7 +194,7 @@ std::string URIAuthority::Str() const
   if (!this->dataPtr->host.empty() ||
       (this->dataPtr->emptyHostValid && this->dataPtr->hasEmptyHost))
   {
-    std::string result = "//";
+    std::string result = kAuthDelim;
     result += this->dataPtr->userInfo.empty() ? "" :
       this->dataPtr->userInfo + "@";
     result += this->dataPtr->host;
@@ -232,7 +232,7 @@ bool URIAuthority::Valid(const std::string &_str, bool _emptyHostValid)
     return true;
 
   // The authority must start with two forward slashes
-  if (str.find("//") != 0)
+  if (str.find(kAuthDelim) != 0)
     return false;
 
   auto userInfoIndex = str.find("@", 2);
@@ -333,7 +333,7 @@ bool URIAuthority::Parse(const std::string &_str, bool _emptyHostValid)
 
   this->dataPtr->emptyHostValid = _emptyHostValid;
 
-  if (_str.empty() || _str == "//")
+  if (_str.empty() || _str == kAuthDelim)
   {
     this->dataPtr->hasEmptyHost = true;
     return true;
@@ -968,6 +968,18 @@ URIPath &URI::Path()
 
 /////////////////////////////////////////////////
 const URIPath &URI::Path() const
+{
+  return this->dataPtr->path;
+}
+
+/////////////////////////////////////////////////
+URIPath &URI::PathSegments()
+{
+  return this->dataPtr->path;
+}
+
+/////////////////////////////////////////////////
+const URIPath &URI::PathSegments() const
 {
   return this->dataPtr->path;
 }

--- a/src/URI.cc
+++ b/src/URI.cc
@@ -991,8 +991,8 @@ URIAuthority &URI::Authority()
 {
   if (!this->dataPtr->hasAuthority)
   {
-    ignwarn << "Getting authority of a URI whose authority is included in the"
-            << " path. Get the path instead. URI: [" << this->Str() << "]"
+    ignwarn << "Getting authority of a URI that's set not to have an authority."
+            << "Get the path instead. URI: [" << this->Str() << "]"
             << std::endl;
   }
   return this->dataPtr->authority;
@@ -1003,8 +1003,8 @@ const URIAuthority &URI::Authority() const
 {
   if (!this->dataPtr->hasAuthority)
   {
-    ignwarn << "Getting authority of a URI whose authority is included in the"
-            << " path. Get the path instead. URI: [" << this->Str() << "]"
+    ignwarn << "Getting authority of a URI that's set not to have an authority."
+            << "Get the path instead. URI: [" << this->Str() << "]"
             << std::endl;
   }
   return this->dataPtr->authority;

--- a/src/URI.cc
+++ b/src/URI.cc
@@ -956,7 +956,7 @@ std::string URI::Str() const
 
   if (this->dataPtr->authority)
   {
-    result += (*this->dataPtr->authority).Str() + this->dataPtr->path.Str();
+    result += this->dataPtr->authority->Str() + this->dataPtr->path.Str();
   }
   else
   {
@@ -1036,8 +1036,7 @@ const URIFragment &URI::Fragment() const
 void URI::Clear()
 {
   this->dataPtr->scheme.clear();
-  if (this->dataPtr->authority)
-    (*this->dataPtr->authority).Clear();
+  this->dataPtr->authority.reset();
   this->dataPtr->path.Clear();
   this->dataPtr->query.Clear();
   this->dataPtr->fragment.Clear();
@@ -1239,10 +1238,9 @@ bool URI::Parse(const std::string &_str)
   this->Clear();
   this->SetScheme(localScheme);
 
-  if (this->dataPtr->authority &&
-      (!emptyHostValid || authorityPresent))
+  if (this->dataPtr->authority && (!emptyHostValid || authorityPresent))
   {
-    if (!(*this->dataPtr->authority).Parse(localAuthority, emptyHostValid))
+    if (!this->dataPtr->authority->Parse(localAuthority, emptyHostValid))
       return false;
   }
 

--- a/src/URI.cc
+++ b/src/URI.cc
@@ -594,6 +594,7 @@ void URIPath::Clear()
 {
   this->dataPtr->path.clear();
   this->dataPtr->isAbsolute = false;
+  this->dataPtr->trailingSlash = false;
 }
 
 /////////////////////////////////////////////////
@@ -1036,7 +1037,9 @@ const URIFragment &URI::Fragment() const
 void URI::Clear()
 {
   this->dataPtr->scheme.clear();
-  this->dataPtr->authority.reset();
+  // Set to empty instead of removing value
+  if (this->dataPtr->authority)
+    this->dataPtr->authority = URIAuthority();
   this->dataPtr->path.Clear();
   this->dataPtr->query.Clear();
   this->dataPtr->fragment.Clear();

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -457,7 +457,7 @@ TEST(URITEST, Scheme)
 }
 
 /////////////////////////////////////////////////
-TEST(URITEST, PathWhenHasAuthority)
+TEST(URITEST, PathIfHasAuthority)
 {
   URI uri;
   uri.SetHasAuthority(true);

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -867,8 +867,10 @@ TEST(URITEST, HasAuthority)
     URI uri("https://john.doe@www.example.com:123/forum/questions/");
 
     EXPECT_TRUE(uri.Authority().Str().empty());
-    EXPECT_EQ("john.doe@www.example.com:123/forum/questions/", uri.Path().Str());
-    EXPECT_EQ("https://john.doe@www.example.com:123/forum/questions/", uri.Str());
+    EXPECT_EQ("john.doe@www.example.com:123/forum/questions/",
+        uri.Path().Str());
+    EXPECT_EQ("https://john.doe@www.example.com:123/forum/questions/",
+        uri.Str());
 
     // Modifyng authority has no affect on string
     uri.Authority() = URIAuthority("//new_authority.com");
@@ -878,8 +880,10 @@ TEST(URITEST, HasAuthority)
     EXPECT_FALSE(uri.Authority().Port());
     EXPECT_EQ("//new_authority.com", uri.Authority().Str());
 
-    EXPECT_EQ("john.doe@www.example.com:123/forum/questions/", uri.Path().Str());
-    EXPECT_EQ("https://john.doe@www.example.com:123/forum/questions/", uri.Str());
+    EXPECT_EQ("john.doe@www.example.com:123/forum/questions/",
+        uri.Path().Str());
+    EXPECT_EQ("https://john.doe@www.example.com:123/forum/questions/",
+        uri.Str());
 
     // Modifyng path updates string
     uri.Path() = URIPath("newest_authority.com/another/path");

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -483,12 +483,12 @@ TEST(URITEST, PathIfHasAuthority)
 
   EXPECT_TRUE(uri.Parse("file://var/run/test"));
   EXPECT_EQ(uri.Str(), "file://var/run/test");
-  EXPECT_EQ((*uri.Authority()).Str(), "//var");
+  EXPECT_EQ(uri.Authority()->Str(), "//var");
   EXPECT_EQ(uri.Path().Str(), "/run/test");
   EXPECT_TRUE(uri.Path().IsAbsolute());
 
   EXPECT_TRUE(uri.Parse("file://test%20space"));
-  EXPECT_EQ("//test%20space", (*uri.Authority()).Str());
+  EXPECT_EQ("//test%20space", uri.Authority()->Str());
   EXPECT_EQ("", uri.Path().Str());
 
   EXPECT_TRUE(uri.Parse("file:///abs/path/test"));
@@ -747,52 +747,52 @@ TEST(URITEST, WikipediaTests)
   EXPECT_TRUE(uri.Parse("https://john.doe@www.example.com:123/forum/questions"
         "/?tag=networking&order=newest#top"));
   EXPECT_EQ("https", uri.Scheme());
-  EXPECT_EQ("john.doe", (*uri.Authority()).UserInfo());
-  EXPECT_EQ("www.example.com", (*uri.Authority()).Host());
-  EXPECT_EQ(123, *(*uri.Authority()).Port());
-  EXPECT_EQ("//john.doe@www.example.com:123", (*uri.Authority()).Str());
+  EXPECT_EQ("john.doe", uri.Authority()->UserInfo());
+  EXPECT_EQ("www.example.com", uri.Authority()->Host());
+  EXPECT_EQ(123, *uri.Authority()->Port());
+  EXPECT_EQ("//john.doe@www.example.com:123", uri.Authority()->Str());
   EXPECT_EQ("/forum/questions/", uri.Path().Str());
   EXPECT_EQ("?tag=networking&order=newest", uri.Query().Str());
   EXPECT_EQ("#top", uri.Fragment().Str());
 
   EXPECT_TRUE(uri.Parse("ldap://[2001:db8::7]/c=GB?objectClass?one"));
   EXPECT_EQ("ldap", uri.Scheme());
-  EXPECT_EQ("[2001:db8::7]", (*uri.Authority()).Host());
-  EXPECT_EQ("//[2001:db8::7]", (*uri.Authority()).Str());
+  EXPECT_EQ("[2001:db8::7]", uri.Authority()->Host());
+  EXPECT_EQ("//[2001:db8::7]", uri.Authority()->Str());
   EXPECT_EQ("/c=GB", uri.Path().Str());
   EXPECT_EQ("?objectClass?one", uri.Query().Str());
 
   EXPECT_TRUE(uri.Parse("mailto:John.Doe@example.com"));
   EXPECT_EQ("mailto", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).Str().empty());
+  EXPECT_TRUE(uri.Authority()->Str().empty());
   EXPECT_EQ("John.Doe@example.com", uri.Path().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
   EXPECT_TRUE(uri.Parse("news:comp.infosystems.www.servers.unix"));
   EXPECT_EQ("news", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).Str().empty());
+  EXPECT_TRUE(uri.Authority()->Str().empty());
   EXPECT_EQ("comp.infosystems.www.servers.unix", uri.Path().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
   EXPECT_TRUE(uri.Parse("tel:+1-816-555-1212"));
   EXPECT_EQ("tel", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).Str().empty());
+  EXPECT_TRUE(uri.Authority()->Str().empty());
   EXPECT_EQ("+1-816-555-1212", uri.Path().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
   EXPECT_TRUE(uri.Parse("telnet://192.0.2.16:80/"));
   EXPECT_EQ("telnet", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).UserInfo().empty());
-  EXPECT_EQ("192.0.2.16", (*uri.Authority()).Host());
-  EXPECT_EQ(80, (*uri.Authority()).Port());
+  EXPECT_TRUE(uri.Authority()->UserInfo().empty());
+  EXPECT_EQ("192.0.2.16", uri.Authority()->Host());
+  EXPECT_EQ(80, uri.Authority()->Port());
   EXPECT_EQ("/", uri.Path().Str());
 
   EXPECT_TRUE(uri.Parse("urn:oasis:names:specification:docbook:dtd:xml:4.1.2"));
   EXPECT_EQ("urn", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).Str().empty());
+  EXPECT_TRUE(uri.Authority()->Str().empty());
   EXPECT_EQ("oasis:names:specification:docbook:dtd:xml:4.1.2",
       uri.Path().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
@@ -841,16 +841,16 @@ TEST(URITEST, File)
 
   EXPECT_TRUE(uri.Parse("file:relative/path"));
   EXPECT_EQ("relative/path", uri.Path().Str());
-  EXPECT_FALSE((*uri.Authority()).EmptyHostValid());
+  EXPECT_FALSE(uri.Authority()->EmptyHostValid());
 
   EXPECT_TRUE(uri.Parse("file:/abs/path"));
   EXPECT_EQ("/abs/path", uri.Path().Str());
-  EXPECT_FALSE((*uri.Authority()).EmptyHostValid());
+  EXPECT_FALSE(uri.Authority()->EmptyHostValid());
 
   // Empty host is valid for file: scheme
   EXPECT_TRUE(uri.Parse("file:///abs/path"));
   EXPECT_EQ("/abs/path", uri.Path().Str());
-  EXPECT_TRUE((*uri.Authority()).EmptyHostValid());
+  EXPECT_TRUE(uri.Authority()->EmptyHostValid());
 }
 
 //////////////////////////////////////////////////
@@ -861,7 +861,7 @@ TEST(URITEST, WinPath)
       true);
   EXPECT_TRUE(uri.Authority());
   EXPECT_EQ("file", uri.Scheme());
-  EXPECT_TRUE((*uri.Authority()).Str().empty());
+  EXPECT_TRUE(uri.Authority()->Str().empty());
   EXPECT_EQ("file:D:/my/test/dir/world.sdf", uri.Str());
 }
 
@@ -890,15 +890,15 @@ TEST(URITEST, HasAuthority)
     URI uri("https://john.doe@www.example.com:123/forum/questions/", true);
 
     EXPECT_TRUE(uri.Authority());
-    EXPECT_EQ("john.doe", (*uri.Authority()).UserInfo());
-    EXPECT_EQ("www.example.com", (*uri.Authority()).Host());
-    EXPECT_EQ(123, *(*uri.Authority()).Port());
-    EXPECT_EQ("//john.doe@www.example.com:123", (*uri.Authority()).Str());
+    EXPECT_EQ("john.doe", uri.Authority()->UserInfo());
+    EXPECT_EQ("www.example.com", uri.Authority()->Host());
+    EXPECT_EQ(123, *uri.Authority()->Port());
+    EXPECT_EQ("//john.doe@www.example.com:123", uri.Authority()->Str());
 
     EXPECT_EQ("/forum/questions/", uri.Path().Str());
 
     uri.SetAuthority(URIAuthority("//new_authority.com"));
-    EXPECT_EQ("//new_authority.com", (*uri.Authority()).Str());
+    EXPECT_EQ("//new_authority.com", uri.Authority()->Str());
     EXPECT_EQ("/forum/questions/", uri.Path().Str());
     EXPECT_EQ("https://new_authority.com/forum/questions/", uri.Str());
   }
@@ -925,9 +925,9 @@ TEST(URITEST, Resource)
     EXPECT_TRUE(uri.Parse("model://model_name/meshes/mesh.dae"));
     EXPECT_EQ("model", uri.Scheme());
     EXPECT_TRUE(uri.Authority());
-    EXPECT_EQ("//model_name", (*uri.Authority()).Str());
-    EXPECT_EQ("model_name", (*uri.Authority()).Host());
-    EXPECT_TRUE((*uri.Authority()).UserInfo().empty());
+    EXPECT_EQ("//model_name", uri.Authority()->Str());
+    EXPECT_EQ("model_name", uri.Authority()->Host());
+    EXPECT_TRUE(uri.Authority()->UserInfo().empty());
     EXPECT_EQ("/meshes/mesh.dae", uri.Path().Str());
     EXPECT_TRUE(uri.Query().Str().empty());
     EXPECT_TRUE(uri.Fragment().Str().empty());
@@ -951,9 +951,9 @@ TEST(URITEST, Resource)
     EXPECT_TRUE(uri.Parse("model://model_name"));
     EXPECT_EQ("model", uri.Scheme());
     EXPECT_TRUE(uri.Authority());
-    EXPECT_EQ("//model_name", (*uri.Authority()).Str());
-    EXPECT_EQ("model_name", (*uri.Authority()).Host());
-    EXPECT_TRUE((*uri.Authority()).UserInfo().empty());
+    EXPECT_EQ("//model_name", uri.Authority()->Str());
+    EXPECT_EQ("model_name", uri.Authority()->Host());
+    EXPECT_TRUE(uri.Authority()->UserInfo().empty());
     EXPECT_TRUE(uri.Path().Str().empty());
     EXPECT_TRUE(uri.Query().Str().empty());
     EXPECT_TRUE(uri.Fragment().Str().empty());
@@ -977,9 +977,9 @@ TEST(URITEST, Resource)
     EXPECT_TRUE(uri.Parse("package://package_name/models/model"));
     EXPECT_EQ("package", uri.Scheme());
     EXPECT_TRUE(uri.Authority());
-    EXPECT_EQ("//package_name", (*uri.Authority()).Str());
-    EXPECT_EQ("package_name", (*uri.Authority()).Host());
-    EXPECT_TRUE((*uri.Authority()).UserInfo().empty());
+    EXPECT_EQ("//package_name", uri.Authority()->Str());
+    EXPECT_EQ("package_name", uri.Authority()->Host());
+    EXPECT_TRUE(uri.Authority()->UserInfo().empty());
     EXPECT_EQ("/models/model", uri.Path().Str());
     EXPECT_TRUE(uri.Query().Str().empty());
     EXPECT_TRUE(uri.Fragment().Str().empty());

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -454,51 +454,53 @@ TEST(URITEST, Path)
   URI uri;
   uri.SetScheme("data");
 
-  uri.Path() = uri.Path() / "world";
+  uri.PathSegments() = uri.PathSegments() / "world";
   EXPECT_EQ(uri.Str(), "data:world");
 
-  uri.Path() /= "default";
+  uri.PathSegments() /= "default";
   EXPECT_EQ(uri.Str(), "data:world/default");
 
   EXPECT_TRUE(uri.Parse("file:///var/run/test"));
 
   EXPECT_TRUE(uri.Parse("file:/var/run/test"));
   EXPECT_EQ(uri.Str(), "file:/var/run/test");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 
   EXPECT_TRUE(uri.Parse("file://var/run/test"));
   EXPECT_EQ(uri.Str(), "file://var/run/test");
-  EXPECT_EQ(uri.Path().Str(), "/run/test");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_EQ(uri.Authority().Str(), "//var");
+  EXPECT_EQ(uri.PathSegments().Str(), "/run/test");
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
+
   EXPECT_TRUE(uri.Parse("file://test%20space"));
   EXPECT_EQ(uri.Authority().Str(), "//test%20space");
-  EXPECT_TRUE(uri.Path().Str().empty());
+  EXPECT_TRUE(uri.PathSegments().Str().empty());
 
   EXPECT_TRUE(uri.Parse("file:///abs/path/test"));
   EXPECT_EQ(uri.Str(), "file:///abs/path/test");
-  EXPECT_EQ(uri.Path().Str(), "/abs/path/test");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_EQ(uri.PathSegments().Str(), "/abs/path/test");
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 
   uri.Parse("file:/var/run/test");
   EXPECT_EQ(uri.Str(), "file:/var/run/test");
-  EXPECT_EQ(uri.Path().Str(), "/var/run/test");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_EQ(uri.PathSegments().Str(), "/var/run/test");
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 
   EXPECT_FALSE(uri.Parse("file://test+space"));
 
   EXPECT_TRUE(uri.Parse("file:/test+space"));
   EXPECT_EQ(uri.Str(), "file:/test+space");
-  EXPECT_EQ(uri.Path().Str(), "/test+space");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_EQ(uri.PathSegments().Str(), "/test+space");
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 
   EXPECT_TRUE(uri.Parse("file:/test%20space"));
   EXPECT_EQ(uri.Str(), "file:/test%20space");
-  EXPECT_EQ(uri.Path().Str(), "/test%20space");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_EQ(uri.PathSegments().Str(), "/test%20space");
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 
   uri.Parse("file://C:/Users");
   EXPECT_EQ(uri.Str(), "file:C:/Users");
-  EXPECT_TRUE(uri.Path().IsAbsolute());
+  EXPECT_TRUE(uri.PathSegments().IsAbsolute());
 }
 
 /////////////////////////////////////////////////
@@ -506,13 +508,13 @@ TEST(URITEST, PathCopy)
 {
   URI uri;
   uri.SetScheme("data");
-  uri.Path().PushFront("world");
+  uri.PathSegments().PushFront("world");
 
   const auto uriCopy(uri);
-  const auto pathCopy(uriCopy.Path() / "default");
+  const auto pathCopy(uriCopy.PathSegments() / "default");
 
-  EXPECT_NE(uri.Path().Str(), pathCopy.Str());
-  EXPECT_EQ(uri.Path().Str(), "world");
+  EXPECT_NE(uri.PathSegments().Str(), pathCopy.Str());
+  EXPECT_EQ(uri.PathSegments().Str(), "world");
   EXPECT_EQ(pathCopy.Str(), "world/default");
 }
 
@@ -525,15 +527,15 @@ TEST(URITEST, Query)
   uri.Query().Insert("p", "v");
   EXPECT_EQ(uri.Str(), "data:?p=v");
 
-  uri.Path().PushFront("default");
+  uri.PathSegments().PushFront("default");
   EXPECT_EQ(uri.Str(), "data:default?p=v");
 
-  uri.Path().PushFront("world");
+  uri.PathSegments().PushFront("world");
   EXPECT_EQ(uri.Str(), "data:world/default?p=v");
 
   URI uri2 = uri;
 
-  uri.Path().Clear();
+  uri.PathSegments().Clear();
   EXPECT_EQ(uri.Str(), "data:?p=v");
 
   uri.Query().Clear();
@@ -570,15 +572,15 @@ TEST(URITEST, Fragment)
   uri.Fragment() = "#f";
   EXPECT_EQ(uri.Str(), "data:#f");
 
-  uri.Path().PushFront("default");
+  uri.PathSegments().PushFront("default");
   EXPECT_EQ(uri.Str(), "data:default#f");
 
-  uri.Path().PushFront("world");
+  uri.PathSegments().PushFront("world");
   EXPECT_EQ(uri.Str(), "data:world/default#f");
 
   URI uri2 = uri;
 
-  uri.Path().Clear();
+  uri.PathSegments().Clear();
   EXPECT_EQ(uri.Str(), "data:#f");
 
   uri.Fragment().Clear();
@@ -677,7 +679,7 @@ TEST(URITEST, WikipediaTests)
   EXPECT_EQ("www.example.com", uri.Authority().Host());
   EXPECT_EQ(123, *uri.Authority().Port());
   EXPECT_EQ("//john.doe@www.example.com:123", uri.Authority().Str());
-  EXPECT_EQ("/forum/questions/", uri.Path().Str());
+  EXPECT_EQ("/forum/questions/", uri.PathSegments().Str());
   EXPECT_EQ("?tag=networking&order=newest", uri.Query().Str());
   EXPECT_EQ("#top", uri.Fragment().Str());
 
@@ -685,27 +687,27 @@ TEST(URITEST, WikipediaTests)
   EXPECT_EQ("ldap", uri.Scheme());
   EXPECT_EQ("[2001:db8::7]", uri.Authority().Host());
   EXPECT_EQ("//[2001:db8::7]", uri.Authority().Str());
-  EXPECT_EQ("/c=GB", uri.Path().Str());
+  EXPECT_EQ("/c=GB", uri.PathSegments().Str());
   EXPECT_EQ("?objectClass?one", uri.Query().Str());
 
   EXPECT_TRUE(uri.Parse("mailto:John.Doe@example.com"));
   EXPECT_EQ("mailto", uri.Scheme());
   EXPECT_TRUE(uri.Authority().Str().empty());
-  EXPECT_EQ("John.Doe@example.com", uri.Path().Str());
+  EXPECT_EQ("John.Doe@example.com", uri.PathSegments().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
   EXPECT_TRUE(uri.Parse("news:comp.infosystems.www.servers.unix"));
   EXPECT_EQ("news", uri.Scheme());
   EXPECT_TRUE(uri.Authority().Str().empty());
-  EXPECT_EQ("comp.infosystems.www.servers.unix", uri.Path().Str());
+  EXPECT_EQ("comp.infosystems.www.servers.unix", uri.PathSegments().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
   EXPECT_TRUE(uri.Parse("tel:+1-816-555-1212"));
   EXPECT_EQ("tel", uri.Scheme());
   EXPECT_TRUE(uri.Authority().Str().empty());
-  EXPECT_EQ("+1-816-555-1212", uri.Path().Str());
+  EXPECT_EQ("+1-816-555-1212", uri.PathSegments().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 
@@ -714,13 +716,13 @@ TEST(URITEST, WikipediaTests)
   EXPECT_TRUE(uri.Authority().UserInfo().empty());
   EXPECT_EQ("192.0.2.16", uri.Authority().Host());
   EXPECT_EQ(80, uri.Authority().Port());
-  EXPECT_EQ("/", uri.Path().Str());
+  EXPECT_EQ("/", uri.PathSegments().Str());
 
   EXPECT_TRUE(uri.Parse("urn:oasis:names:specification:docbook:dtd:xml:4.1.2"));
   EXPECT_EQ("urn", uri.Scheme());
   EXPECT_TRUE(uri.Authority().Str().empty());
   EXPECT_EQ("oasis:names:specification:docbook:dtd:xml:4.1.2",
-      uri.Path().Str());
+      uri.PathSegments().Str());
   EXPECT_TRUE(uri.Query().Str().empty());
   EXPECT_TRUE(uri.Fragment().Str().empty());
 }
@@ -758,20 +760,21 @@ TEST(URITEST, URIAuthority)
   EXPECT_TRUE(auth2.Valid());
 }
 
+//////////////////////////////////////////////////
 TEST(URITEST, File)
 {
   URI uri;
   EXPECT_TRUE(uri.Parse("file:relative/path"));
-  EXPECT_EQ("relative/path", uri.Path().Str());
+  EXPECT_EQ("relative/path", uri.PathSegments().Str());
   EXPECT_FALSE(uri.Authority().EmptyHostValid());
 
   EXPECT_TRUE(uri.Parse("file:/abs/path"));
-  EXPECT_EQ("/abs/path", uri.Path().Str());
+  EXPECT_EQ("/abs/path", uri.PathSegments().Str());
   EXPECT_FALSE(uri.Authority().EmptyHostValid());
 
   // Empty host is valid for file: scheme
   EXPECT_TRUE(uri.Parse("file:///abs/path"));
-  EXPECT_EQ("/abs/path", uri.Path().Str());
+  EXPECT_EQ("/abs/path", uri.PathSegments().Str());
   EXPECT_TRUE(uri.Authority().EmptyHostValid());
 }
 
@@ -782,6 +785,47 @@ TEST(URITEST, WinPath)
   EXPECT_EQ("file", uri.Scheme());
   EXPECT_TRUE(uri.Authority().Str().empty());
   EXPECT_EQ("file:D:/my/test/dir/world.sdf", uri.Str());
+}
+
+//////////////////////////////////////////////////
+TEST(URITEST, Resource)
+{
+  // Test URIs that are commonly used for resources in Ignition
+  {
+    URI uri;
+    EXPECT_TRUE(uri.Parse("model://model_name/meshes/mesh.dae"));
+    EXPECT_EQ("model", uri.Scheme());
+    EXPECT_EQ("//model_name", uri.Authority().Str());
+    EXPECT_EQ("model_name", uri.Authority().Host());
+    EXPECT_TRUE(uri.Authority().UserInfo().empty());
+    EXPECT_EQ("/meshes/mesh.dae", uri.PathSegments().Str());
+    EXPECT_TRUE(uri.Query().Str().empty());
+    EXPECT_TRUE(uri.Fragment().Str().empty());
+  }
+
+  {
+    URI uri;
+    EXPECT_TRUE(uri.Parse("model://model_name"));
+    EXPECT_EQ("model", uri.Scheme());
+    EXPECT_EQ("//model_name", uri.Authority().Str());
+    EXPECT_EQ("model_name", uri.Authority().Host());
+    EXPECT_TRUE(uri.Authority().UserInfo().empty());
+    EXPECT_TRUE(uri.PathSegments().Str().empty());
+    EXPECT_TRUE(uri.Query().Str().empty());
+    EXPECT_TRUE(uri.Fragment().Str().empty());
+  }
+
+  {
+    URI uri;
+    EXPECT_TRUE(uri.Parse("package://package_name/models/model"));
+    EXPECT_EQ("package", uri.Scheme());
+    EXPECT_EQ("//package_name", uri.Authority().Str());
+    EXPECT_EQ("package_name", uri.Authority().Host());
+    EXPECT_TRUE(uri.Authority().UserInfo().empty());
+    EXPECT_EQ("/models/model", uri.PathSegments().Str());
+    EXPECT_TRUE(uri.Query().Str().empty());
+    EXPECT_TRUE(uri.Fragment().Str().empty());
+  }
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

While working on https://github.com/ignition-tooling/release-tools/issues/361, I noticed that the changes in the URI introduced in `ign-common4` were very disruptive, see https://github.com/ignitionrobotics/ign-fuel-tools/pull/163#issuecomment-768050613.

This is a proposal to reduce the impact of these changes and maintain support for the "URI" format that is widespread in the ecosystem (`model://` / `package://`).  Another goal of this PR is to make the changes more evident to downstream users through deprecation warnings.

Because there was no concept of "authority" up to `ign-common3`, it's safe to assume that users are currently embedding the authority into the path. This PR deprecates `URI::Path()` to hint to the user that something has changed and adds an alternative function, `PathSegments`, that does the same. When the user checks the migration guide, there are instructions to use `Authority` + `PathSegments`.

One thing I considered was maintaining the behaviour of `Path` as it was before, that is, it would set / get both authority and path segments. I could look into it if it sounds interesting.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Added example world and/or tutorial
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
