### PR TITLE
Fix markdown in tutorial

### DIFF
--- a/tutorials/hw-encoding.md
+++ b/tutorials/hw-encoding.md
@@ -21,8 +21,8 @@ so performance-wise, the rest of the GPU should be unaffected).
 In order to get HW accelerated encoding working, you need to get 3 things right:
 
 1. The encoder type
-1. The HW device to be used
-1. Whether to use a specialized HW surface
+2. The HW device to be used
+3. Whether to use a specialized HW surface
 
 ## 1. Encoder types
 


### PR DESCRIPTION
Fixing the Markdown syntax in the tutorial added in #169. I first thought it would get fixed by addressing ignitionrobotics/docs#145, but that showed to be a wontfix, so I'm fixing the syntax here.