### PR TITLE
Rotate capsule to Z-up

### DIFF
--- a/graphics/include/ignition/common/MeshManager.hh
+++ b/graphics/include/ignition/common/MeshManager.hh
@@ -167,9 +167,9 @@ namespace ignition
      /// \brief Create a capsule mesh
      /// \param[in] _name the name of the new mesh
      /// \param[in] _radius the radius of the capsule in the x y plane
-     /// \param[in] _length length of the body
+     /// \param[in] _length length of the capsule along z
      /// \param[in] _rings the number of circles along the height
-     /// \param[in] _segments the number of segment per circle
+     /// \param[in] _segments the number of segments per circle
      public: void CreateCapsule(const std::string &_name,
                                 const double radius,
                                 const double length,

--- a/graphics/src/MeshManager.cc
+++ b/graphics/src/MeshManager.cc
@@ -919,7 +919,8 @@ void MeshManager::CreateCapsule(const std::string &_name,
 
   SubMesh subMesh;
 
-  // Based on https://github.com/godotengine/godot primitive_meshes.cpp
+  // Based on https://github.com/godotengine/godot/blob/3.2.3-stable/scene/resources/primitive_meshes.cpp
+  // Rotated to be Z-up
   int prevRow, thisRow, point;
   double x, y, z, u, v, w;
   const double oneThird = 1.0 / 3.0;
@@ -930,31 +931,33 @@ void MeshManager::CreateCapsule(const std::string &_name,
   /* top hemisphere */
   thisRow = 0;
   prevRow = 0;
-  for (unsigned int j = 0; j <= (_rings + 1); j++) {
+  for (unsigned int j = 0; j <= (_rings + 1); j++)
+  {
     v = j;
 
     v /= (_rings + 1);
     w = sin(0.5 * IGN_PI * v);
-    y = _radius * cos(0.5 * IGN_PI * v);
+    z = _radius * cos(0.5 * IGN_PI * v);
 
-    for (unsigned int i = 0; i <= _segments; i++) {
+    for (unsigned int i = 0; i <= _segments; i++)
+    {
       u = i;
       u /= _segments;
 
       x = -sin(u * (IGN_PI * 2.0));
-      z = cos(u * (IGN_PI * 2.0));
+      y = cos(u * (IGN_PI * 2.0));
 
-      ignition::math::Vector3d p(
-      x * _radius * w, y, -z * _radius * w);
+      ignition::math::Vector3d p(x * _radius * w, y * _radius * w, z);
       // Compute vertex
       subMesh.AddVertex(ignition::math::Vector3d(
-        p + ignition::math::Vector3d(0.0, 0.5 * _length, 0.0)));
+        p + ignition::math::Vector3d(0.0, 0.0, 0.5 * _length)));
       subMesh.AddTexCoord({u, v * oneThird});
       subMesh.AddNormal(p.Normalize());
 
       point++;
 
-      if (i > 0 && j > 0) {
+      if (i > 0 && j > 0)
+      {
         subMesh.AddIndex(thisRow + i - 1);
         subMesh.AddIndex(prevRow + i);
         subMesh.AddIndex(prevRow + i - 1);
@@ -971,30 +974,32 @@ void MeshManager::CreateCapsule(const std::string &_name,
   /* cylinder */
   thisRow = point;
   prevRow = 0;
-  for (unsigned int j = 0; j <= (_rings + 1); j++) {
+  for (unsigned int j = 0; j <= (_rings + 1); j++)
+  {
     v = j;
     v /= (_rings + 1);
 
-    y = _length * v;
-    y = (_length * 0.5) - y;
+    z = _length * v;
+    z = (_length * 0.5) - z;
 
-    for (unsigned int i = 0; i <= _segments; i++) {
+    for (unsigned int i = 0; i <= _segments; i++)
+    {
       u = i;
       u /= _segments;
 
       x = -sin(u * (IGN_PI * 2.0));
-      z = cos(u * (IGN_PI * 2.0));
+      y = cos(u * (IGN_PI * 2.0));
 
-      ignition::math::Vector3d p(
-      x * _radius, y, -z * _radius);
+      ignition::math::Vector3d p(x * _radius, y * _radius, z);
 
       // Compute vertex
       subMesh.AddVertex(p);
       subMesh.AddTexCoord({u, oneThird + (v * oneThird)});
-      subMesh.AddNormal(ignition::math::Vector3d(x, 0.0, -z));
+      subMesh.AddNormal(ignition::math::Vector3d(x, y, 0.0));
       point++;
 
-      if (i > 0 && j > 0) {
+      if (i > 0 && j > 0)
+      {
         subMesh.AddIndex(thisRow + i - 1);
         subMesh.AddIndex(prevRow + i);
         subMesh.AddIndex(prevRow + i - 1);
@@ -1011,31 +1016,33 @@ void MeshManager::CreateCapsule(const std::string &_name,
   /* bottom hemisphere */
   thisRow = point;
   prevRow = 0;
-  for (unsigned int j = 0; j <= (_rings + 1); j++) {
+  for (unsigned int j = 0; j <= (_rings + 1); j++)
+  {
     v = j;
 
     v /= (_rings + 1);
     v += 1.0;
     w = sin(0.5 * IGN_PI * v);
-    y = _radius * cos(0.5 * IGN_PI * v);
+    z = _radius * cos(0.5 * IGN_PI * v);
 
-    for (unsigned int i = 0; i <= _segments; i++) {
+    for (unsigned int i = 0; i <= _segments; i++)
+    {
       double u2 = static_cast<double>(i);
       u2 /= _segments;
 
       x = -sin(u2 * (IGN_PI * 2.0));
-      z = cos(u2 * (IGN_PI * 2.0));
+      y = cos(u2 * (IGN_PI * 2.0));
 
-      ignition::math::Vector3d p(
-      x * _radius * w, y, -z * _radius * w);
+      ignition::math::Vector3d p(x * _radius * w, y * _radius * w, z);
       // Compute vertex
       subMesh.AddVertex(ignition::math::Vector3d(
-        p + ignition::math::Vector3d(0.0, -0.5 * _length, 0.0)));
+        p + ignition::math::Vector3d(0.0, 0.0, -0.5 * _length)));
       subMesh.AddTexCoord({u2, twoThirds + ((v - 1.0) * oneThird)});
       subMesh.AddNormal(p.Normalize());
       point++;
 
-      if (i > 0 && j > 0) {
+      if (i > 0 && j > 0)
+      {
         subMesh.AddIndex(thisRow + i - 1);
         subMesh.AddIndex(prevRow + i);
         subMesh.AddIndex(prevRow + i - 1);

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -421,7 +421,7 @@ TEST_F(SubMeshTest, Volume)
     checkIndexes(unitEllipsoid2);
 
     // The new mesh should have more vertex, but it should be introduced in the
-    // meshmanager. It should be the same number becuase it was not modified.
+    // meshmanager. It should be the same number because it was not modified.
     EXPECT_EQ(unitEllipsoid->VertexCount(), unitEllipsoid2->VertexCount());
 
     // A larger cylinder needs to have higher resolution in order to get the
@@ -452,7 +452,7 @@ TEST_F(SubMeshTest, Volume)
       common::MeshManager::Instance()->MeshByName("capsule");
 
     // the new mesh should have more vertex, but it should be introduced in the
-    // meshmanager. It should be the same number becuase it was not modified.
+    // meshmanager. It should be the same number because it was not modified.
     EXPECT_EQ(unitCapsule->VertexCount(), unitCapsule2->VertexCount());
 
     common::MeshManager::Instance()->CreateCapsule("other_capsule",


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

The capsule code was using Y-up, but Ignition uses Z-up. In particular, see the capsule description on [Ignition Math](https://github.com/ignitionrobotics/ign-math/blob/b84710d4fb05c953a80759b5cb6599b7a07d0df0/include/ignition/math/Capsule.hh#L37-L40) and on [SDFormat](https://github.com/osrf/sdformat/blob/20310281c555767a6df39a98fb3a4f1d677faf96/sdf/1.8/capsule_shape.sdf#L7).

Before | After
-- | --
![rolling_shapes_new2](https://user-images.githubusercontent.com/5751272/111852665-1532e280-88d5-11eb-9806-f1a07234b789.gif) | ![rolling_shapes_correct](https://user-images.githubusercontent.com/5751272/111852671-1bc15a00-88d5-11eb-90f3-dde55c8472e6.gif)



## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
