### PR TITLE
Fix crash when using BVH animations

### DIFF
--- a/graphics/src/Skeleton.cc
+++ b/graphics/src/Skeleton.cc
@@ -30,7 +30,7 @@ class ignition::common::Skeleton::Implementation
     RawNodeWeights;
 
   /// \brief the root node
-  public: SkeletonNode *root;
+  public: SkeletonNode *root{nullptr};
 
   /// \brief The dictionary of nodes, indexed by name
   public: SkeletonNodeMap nodes;
@@ -68,7 +68,6 @@ class ignition::common::Skeleton::Implementation
 Skeleton::Skeleton()
 : dataPtr(ignition::utils::MakeUniqueImpl<Implementation>())
 {
-  this->dataPtr->root = nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -82,10 +81,13 @@ Skeleton::Skeleton(SkeletonNode *_root)
 //////////////////////////////////////////////////
 Skeleton::~Skeleton()
 {
-  for (auto& kv : this->dataPtr->nodes)
+  for (auto &kv : this->dataPtr->nodes)
     delete kv.second;
-  for (auto& a : this->dataPtr->anims)
+  this->dataPtr->nodes.clear();
+
+  for (auto &a : this->dataPtr->anims)
     delete a;
+  this->dataPtr->anims.clear();
 }
 
 //////////////////////////////////////////////////
@@ -462,7 +464,10 @@ bool Skeleton::AddBvhAnimation(const std::string &_bvhFile, double _scale)
           * math::Matrix4d(skinNode->Transform().Rotation());
   }
 
-  this->dataPtr->anims.push_back(skel->Animation(0u));
+  // Copy pointer from temp skeleton before it's deleted
+  auto newAnim = new SkeletonAnimation(skel->Animation(0u)->Name());
+  *newAnim = *skel->Animation(0u);
+  this->dataPtr->anims.push_back(newAnim);
   this->dataPtr->mapAnimSkin.push_back(skelMap);
   this->dataPtr->alignTranslate.push_back(translations);
   this->dataPtr->alignRotate.push_back(rotations);


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

Actors using BVH animations have been crashing `ign-gazebo`, probably since #136, see https://github.com/ignitionrobotics/ign-common/pull/136#issuecomment-805449865.

The problem is that we were creating a temporary `Skeleton`, getting a pointer to its animation, and then deleting the original skeleton. Now that the skeleton is properly destroyed, we also destroy that pointer. The solution is to make a copy so we can keep ownership.

This needs to be backported to `ign-common3`, I'm targeting `main` so we can get it into Edifice's first release. I believe this is a critical bug fix.

@adlarkin , I believe you've been looking into this. Maybe you can see if this works?


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests - I suggest we just manually test this right now, and after Edifice's release we come back to add proper tests.
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
