### PR TITLE
Use matching malloc/free for AudioDecoder.

### DIFF
--- a/av/src/AudioDecoder.cc
+++ b/av/src/AudioDecoder.cc
@@ -98,7 +98,7 @@ bool AudioDecoder::Decode(uint8_t **_outBuffer, unsigned int *_outBufferSize)
 
   if (*_outBuffer)
   {
-    delete [] *_outBuffer;
+    free(*_outBuffer);
     *_outBuffer = nullptr;
   }
 

--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -69,7 +69,7 @@ TEST(AudioDecoder, DataBuffer)
   EXPECT_TRUE(audio.Decode(&dataBuffer, &dataBufferSize));
 
   unsigned int dataBufferSize2;
-  uint8_t *dataBuffer2 = new uint8_t[5];
+  uint8_t *dataBuffer2 = static_cast<uint8_t *>(malloc(5));
   EXPECT_TRUE(audio.Decode(&dataBuffer2, &dataBufferSize2));
 
   EXPECT_EQ(dataBufferSize2, dataBufferSize);


### PR DESCRIPTION
Since `_outBuffer` is given to `realloc()` in the middle of `AudioDecoder::Decode()` we use malloc/free for consistency.

`bazel test --copt="-fsanitize=address" --linkopt="-fsanitize=address" //ign_common/av:AudioDecoder_TEST` would still fail due to a read heap-buffer-overflow. I think it has to with the fact that FFmpeg has both packed and planar sample format:
https://ffmpeg.org/doxygen/trunk/group__lavu__sampfmts.html
The current code works for packed format but would read past allocated buffer in planar format case where two channels are stored in `data[0]` and `data[1]` respectively.