### PR TITLE
Bump main to 5.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-common4 VERSION 4.0.0)
+project(ignition-common5 VERSION 5.0.0)
 
 #============================================================================
 # Find ignition-cmake
@@ -14,7 +14,7 @@ set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 #============================================================================
 # Configure the project
 #============================================================================
-ign_configure_project(VERSION_SUFFIX pre2)
+ign_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
+## Ignition Common 5.x
+
+## Ignition Common 5.0.0 (20XX-XX-XX)
+
 ## Ignition Common 4.x
 
-## Ignition Common 4.X.X
+## Ignition Common 4.X.X (20XX-XX-XX)
 
 ## Ignition Common 4.0.0 (2021-03-22)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the ignition-common library
-set(IGN_COMMON_VER 4)
+set(IGN_COMMON_VER 5)
 find_package(ignition-common${IGN_COMMON_VER} QUIET REQUIRED COMPONENTS events profiler)
 
 add_executable(assert_example assert_example.cc)

--- a/tutorials/profiler.md
+++ b/tutorials/profiler.md
@@ -60,10 +60,10 @@ enabled at compile time in order to function.
 cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
 
 # Find the ignition-common library
-find_package(ignition-common4 QUIET REQUIRED COMPONENTS profiler)
+find_package(ignition-common5 QUIET REQUIRED COMPONENTS profiler)
 
 add_executable(profiler_example profiler.cc)
-target_link_libraries(profiler_example ignition-common4::profiler)
+target_link_libraries(profiler_example ignition-common5::profiler)
 # Enable the profiler for the example
 target_compile_definitions(profiler_example PUBLIC "IGN_PROFILER_ENABLE=1")
 ```
@@ -99,10 +99,10 @@ xdg-open $SOURCE_DIR/ign-common/profiler/src/Remotery/vis/index.html
 
 # Use the installation path (Linux)
 # This may vary depending on where you have choosen to install
-xdg-open /usr/share/ignition/ignition-common4/profiler_vis/index.html
+xdg-open /usr/share/ignition/ignition-common5/profiler_vis/index.html
 
 # Use the installation path (macOS)
-open /usr/share/ignition/ignition-common4/profiler_vis/index.html
+open /usr/share/ignition/ignition-common5/profiler_vis/index.html
 ```
 
 ### On Ignition library


### PR DESCRIPTION
Branch `ign-common4` has been created for the Edifice release and 4.0.0 released from that.

The `main` branch now corresponds to version 5.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421