### PR TITLE
Backport #188: Fix crash when using BVH animations

### DIFF
--- a/graphics/include/ignition/common/SkeletonAnimation.hh
+++ b/graphics/include/ignition/common/SkeletonAnimation.hh
@@ -47,6 +47,15 @@ namespace ignition
       /// the animations
       public: ~SkeletonAnimation();
 
+      // NOTE: this is not needed starting in ign-common4 since ign-common4 uses
+      // the IGN_UTILS_IMPL_PTR instead of a raw impl pointer. So, this
+      // method should not be included in forward ports from ign-common3 to
+      // ign-common4
+      /// \brief Assignment operator
+      /// \param[in] _other The new SkeletonAnimation
+      /// \return A reference to this instance
+      public: SkeletonAnimation &operator=(const SkeletonAnimation &_other);
+
       /// \brief Changes the name
       /// \param[in] _name the new name
       public: void SetName(const std::string& _name);

--- a/graphics/src/Skeleton.cc
+++ b/graphics/src/Skeleton.cc
@@ -30,7 +30,7 @@ class ignition::common::SkeletonPrivate
     RawNodeWeights;
 
   /// \brief the root node
-  public: SkeletonNode *root;
+  public: SkeletonNode *root{nullptr};
 
   /// \brief The dictionary of nodes, indexed by name
   public: SkeletonNodeMap nodes;
@@ -68,7 +68,6 @@ class ignition::common::SkeletonPrivate
 Skeleton::Skeleton()
   : data(new SkeletonPrivate)
 {
-  this->data->root = nullptr;
 }
 
 //////////////////////////////////////////////////
@@ -82,10 +81,14 @@ Skeleton::Skeleton(SkeletonNode *_root)
 //////////////////////////////////////////////////
 Skeleton::~Skeleton()
 {
-  for (auto& kv : this->data->nodes)
+  for (auto &kv : this->data->nodes)
     delete kv.second;
-  for (auto& a : this->data->anims)
+  this->data->nodes.clear();
+
+  for (auto &a : this->data->anims)
     delete a;
+  this->data->anims.clear();
+
   delete this->data;
   this->data = NULL;
 }
@@ -463,7 +466,10 @@ bool Skeleton::AddBvhAnimation(const std::string &_bvhFile, double _scale)
           * math::Matrix4d(skinNode->Transform().Rotation());
   }
 
-  this->data->anims.push_back(skel->Animation(0u));
+  // Copy pointer from temp skeleton before it's deleted
+  auto newAnim = new SkeletonAnimation(skel->Animation(0u)->Name());
+  *newAnim = *skel->Animation(0u);
+  this->data->anims.push_back(newAnim);
   this->data->mapAnimSkin.push_back(skelMap);
   this->data->alignTranslate.push_back(translations);
   this->data->alignRotate.push_back(rotations);

--- a/graphics/src/SkeletonAnimation.cc
+++ b/graphics/src/SkeletonAnimation.cc
@@ -51,6 +51,19 @@ SkeletonAnimation::~SkeletonAnimation()
 }
 
 //////////////////////////////////////////////////
+SkeletonAnimation &SkeletonAnimation::operator=(const SkeletonAnimation &_other)
+{
+  if (this == &_other)
+    return *this;
+
+  this->data->name = _other.data->name;
+  this->data->length = _other.data->length;
+  this->data->animations = _other.data->animations;
+
+  return *this;
+}
+
+//////////////////////////////////////////////////
 void SkeletonAnimation::SetName(const std::string &_name)
 {
   this->data->name = _name;


### PR DESCRIPTION
Signed-off-by: Ashton Larkin <ashton@openrobotics.org>

<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

Related to https://github.com/ignitionrobotics/ign-gazebo/issues/647

## Summary
This is a backport of #188. Once this is merged, we should no longer see actors crash at launch (the `ign-common3` branch applies to both Citadel and Dome).

To test this, run `ign gazebo -r actor.sdf` and make sure no crash occurs.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**