### PR TITLE
Fixed colladaLoader on Windows

### DIFF
--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -389,9 +389,13 @@ Mesh *ColladaLoader::Load(const std::string &_filename)
   tinyxml2::XMLDocument xmlDoc;
 
   this->dataPtr->path.clear();
-  if (_filename.rfind('/') != std::string::npos)
+  std::string separator("/");
+#ifdef WIN32
+  separator = std::string("\\");
+#endif
+  if (_filename.rfind(separator) != std::string::npos)
   {
-    this->dataPtr->path = _filename.substr(0, _filename.rfind('/'));
+    this->dataPtr->path = _filename.substr(0, _filename.rfind(separator));
   }
 
   this->dataPtr->filename = _filename;


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Relative image on WIndows was not working because we were using only the UNIX like separator

Related to this PR https://github.com/ignitionrobotics/ign-rendering/pull/291

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
