### PR TITLE
Remove ColladaExporter path constraint

### DIFF
--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -508,7 +508,7 @@ int ColladaExporter::Implementation::ExportImages(
       this->mesh->MaterialByIndex(i);
     std::string imageString = material->TextureImage();
 
-    if (imageString.find("meshes/") != std::string::npos)
+    if (imageString.find("/") != std::string::npos)
     {
       char id[100];
       snprintf(id, sizeof(id), "image_%u", i);
@@ -589,7 +589,7 @@ void ColladaExporter::Implementation::ExportEffects(
         this->mesh->MaterialByIndex(i);
     std::string imageString = material->TextureImage();
 
-    if (imageString.find("meshes/") != std::string::npos)
+    if (imageString.find("/") != std::string::npos)
     {
       tinyxml2::XMLElement *newParamXml =
         _libraryEffectsXml->GetDocument()->NewElement("newparam");
@@ -684,7 +684,7 @@ void ColladaExporter::Implementation::ExportEffects(
       _libraryEffectsXml->GetDocument()->NewElement("diffuse");
     phongXml->LinkEndChild(diffuseXml);
 
-    if (imageString.find("meshes/") != std::string::npos)
+    if (imageString.find("/") != std::string::npos)
     {
       tinyxml2::XMLElement *textureXml =
         _libraryEffectsXml->GetDocument()->NewElement("texture");
@@ -827,7 +827,7 @@ void ColladaExporter::Implementation::ExportVisualScenes(
 
       std::string imageString = material->TextureImage();
 
-      if (imageString.find("meshes/") != std::string::npos)
+      if (imageString.find("/") != std::string::npos)
       {
         tinyxml2::XMLElement *bindVertexInputXml =
           _libraryVisualScenesXml->GetDocument()->NewElement(

--- a/graphics/src/ColladaExporter_TEST.cc
+++ b/graphics/src/ColladaExporter_TEST.cc
@@ -121,6 +121,8 @@ TEST_F(ColladaExporter, ExportCordlessDrill)
       "cordless_drill_exported");
   const auto filenameOutExt = common::joinPaths(filenameOut,
       "meshes", "cordless_drill_exported.dae");
+  const auto filenameOutTexture = common::joinPaths(filenameOut,
+      "materials", "textures", "cordless_drill.png");
 
   // Load original mesh
   common::ColladaLoader loader;
@@ -129,6 +131,10 @@ TEST_F(ColladaExporter, ExportCordlessDrill)
   // Export with extension
   common::ColladaExporter exporter;
   exporter.Export(meshOriginal, filenameOut, true);
+
+  // The export directory and texture should now exist.
+  ASSERT_TRUE(common::exists(filenameOut));
+  EXPECT_TRUE(common::exists(filenameOutTexture));
 
   // Check .dae file
   tinyxml2::XMLDocument xmlDoc;


### PR DESCRIPTION
Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>

# 🦟 Bug fix

Fixes #202 

## Summary
This PR removes the ColladaExporter constraint on the path to include "meshes" in their names to be exported. As per discussion in #202 this check might be related to code from Ignition Gazebo and may not be needed now.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))