### PR TITLE
Remove raw new/delete calls from #205

### DIFF
--- a/graphics/include/ignition/common/Image.hh
+++ b/graphics/include/ignition/common/Image.hh
@@ -210,10 +210,11 @@ namespace ignition
       {
         unsigned int samples = _width * _height;
         unsigned int bufferSize = samples * sizeof(T);
-        T *buffer = new T[samples];
-        memcpy(buffer, _data, bufferSize);
 
-        unsigned char *outputRgbBuffer = new unsigned char[samples * 3];
+        auto buffer = std::vector<T>(samples);
+        memcpy(buffer.data(), _data, bufferSize);
+
+        auto outputRgbBuffer = std::vector<uint8_t>(samples * 3);
 
         // use min and max values found in the data if not specified
         T min = std::numeric_limits<T>::max();
@@ -222,7 +223,7 @@ namespace ignition
         {
           for (unsigned int i = 0; i < samples; ++i)
           {
-            T v = static_cast<T>(buffer[i]);
+            auto v = buffer[i];
             // ignore inf values when computing min/max
             // cast to float when calling isinf to avoid compile error on
             // windows
@@ -245,8 +246,8 @@ namespace ignition
         {
           for (unsigned int i = 0; i < _width; ++i)
           {
-            T v = static_cast<T>(buffer[idx++]);
-            double t = static_cast<double>(v-min) / range;
+            auto v = buffer[idx++];
+            double t = static_cast<double>(v - min) / range;
             if (_flip)
               t = 1.0 - t;
             uint8_t r = static_cast<uint8_t>(255*t);
@@ -256,9 +257,7 @@ namespace ignition
             outputRgbBuffer[outIdx + 2] = r;
           }
         }
-        _output.SetFromData(outputRgbBuffer, _width, _height, RGB_INT8);
-        delete [] outputRgbBuffer;
-        delete [] buffer;
+        _output.SetFromData(outputRgbBuffer.data(), _width, _height, RGB_INT8);
       }
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING

--- a/graphics/src/Image_TEST.cc
+++ b/graphics/src/Image_TEST.cc
@@ -337,7 +337,7 @@ TEST_F(ImageTest, ConvertToRGBImage)
     // create sample image data for testing
     // the image is divided into 4 sections from top to bottom
     // The values in the sections are 10, 20, 30, 40
-    uint8_t *buffer = new uint8_t[size];
+    auto buffer = std::vector<uint8_t>(size);
     for (unsigned int i = 0; i < height; ++i)
     {
       uint8_t v = 10 * static_cast<int>(i / (width/ 4.0) + 1);
@@ -348,7 +348,8 @@ TEST_F(ImageTest, ConvertToRGBImage)
     }
 
     common::Image output;
-    common::Image::ConvertToRGBImage<uint8_t>(buffer, width, height, output);
+    common::Image::ConvertToRGBImage<uint8_t>(
+        buffer.data(), width, height, output);
 
     // Check RGBA data
     unsigned char *data = nullptr;
@@ -383,7 +384,7 @@ TEST_F(ImageTest, ConvertToRGBImage)
     // create sample image data for testing
     // the image is divided into 4 sections from top to bottom
     // The values in the sections are 100, 200, 300, 400
-    uint16_t *buffer = new uint16_t[size];
+    auto buffer = std::vector<uint16_t>(size);
     for (unsigned int i = 0; i < height; ++i)
     {
       uint16_t v = 100 * static_cast<int>(i / (height / 4.0) + 1);
@@ -394,7 +395,8 @@ TEST_F(ImageTest, ConvertToRGBImage)
     }
 
     common::Image output;
-    common::Image::ConvertToRGBImage<uint16_t>(buffer, width, height, output);
+    common::Image::ConvertToRGBImage<uint16_t>(
+        buffer.data(), width, height, output);
 
     // Check RGB data
     unsigned char *data = nullptr;
@@ -430,7 +432,7 @@ TEST_F(ImageTest, ConvertToRGBImage)
     // create sample image data for testing
     // the image is divided into 4 sections from top to bottom
     // The values in the sections are 0.5, 1.0, 1.5, 2.0
-    float *buffer = new float[size];
+    auto buffer = std::vector<float>(size);
     for (unsigned int i = 0; i < height; ++i)
     {
       float v = 0.5f * static_cast<int>(i / (height / 4.0) + 1);
@@ -441,7 +443,8 @@ TEST_F(ImageTest, ConvertToRGBImage)
     }
 
     common::Image output;
-    common::Image::ConvertToRGBImage<float>(buffer, width, height, output);
+    common::Image::ConvertToRGBImage<float>(
+        buffer.data(), width, height, output);
 
     // Check RGB data
     unsigned char *data = nullptr;
@@ -477,7 +480,7 @@ TEST_F(ImageTest, ConvertToRGBImage)
     // create sample image data for testing
     // the image is divided into 4 sections from top to bottom
     // The values in the sections are 0.5, 1.0, 1.5, 2.0
-    float *buffer = new float[size];
+    auto buffer = std::vector<float>(size);
     for (unsigned int i = 0; i < height; ++i)
     {
       float v = 0.5f * static_cast<int>(i / (height / 4.0) + 1);
@@ -490,8 +493,8 @@ TEST_F(ImageTest, ConvertToRGBImage)
     float min = 0.0f;
     float max = 5.0f;
     common::Image output;
-    common::Image::ConvertToRGBImage<float>(buffer, width, height, output,
-        min, max, true);
+    common::Image::ConvertToRGBImage<float>(
+        buffer.data(), width, height, output, min, max, true);
 
     // Check RGB data
     unsigned char *data = nullptr;


### PR DESCRIPTION
I think that we should generally avoid raw `new` and `delete` calls in code going forward.  In this case, the test was also allocating memory without deallocating.

I replaced heap allocations with `std::vector<T>` where it made sense.