### PR TITLE
Prepare for 3.13.0 release

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,9 +21,9 @@ PROJECT_NAME = "ignition-common"
 
 PROJECT_MAJOR = 3
 
-PROJECT_MINOR = 11
+PROJECT_MINOR = 13
 
-PROJECT_PATCH = 1
+PROJECT_PATCH = 0
 
 # Generates config.hh based on the version numbers in CMake code.
 ign_config_header(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-common3 VERSION 3.12.0)
+project(ignition-common3 VERSION 3.13.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,20 @@
 
 ## Ignition Common 3.X.X
 
+## Ignition Common 3.13.0 (2021-04-27)
+
+1. Add function to convert single channel image data to RGB image 
+    * [Pull request #205](https://github.com/ignitionrobotics/ign-common/pull/205)
+
+1. Avoid duplication of / in joinPaths (Windows)
+    * [Pull request #201](https://github.com/ignitionrobotics/ign-common/pull/201)
+
+1. Fix colladaLoader on Windows 
+    * [Pull request #200](https://github.com/ignitionrobotics/ign-common/pull/200)
+
+1. Improved Windows support 
+    * [Pull request #197](https://github.com/ignitionrobotics/ign-common/pull/197)
+
 ## Ignition Common 3.12.0 (2021-04-06)
 
 1. Remove use of _SOURCE and _BINARY dirs in tests.


### PR DESCRIPTION
# 🎈 3.13.0

Preparation for 3.13.0 release.

Comparison to <x.y.z>: https://github.com/ignitionrobotics/<REPO>/compare/ignition-common3_3.12.0...ign-common3

<!-- Add links to PRs that require this release (if needed) -->
Needed by <PR(s)>

## Checklist
- [ ] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
