### PR TITLE
 Fix loading collada files with multiple texcoord sets using the same offset

### DIFF
--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -2167,7 +2167,7 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
               if (!inputs[TEXCOORD].empty())
               {
                 texEqual = true;
-                for (auto pair: texcoordsOffsetToSet)
+                for (auto &pair : texcoordsOffsetToSet)
                 {
                   unsigned int offset = pair.first;
                   unsigned int set = pair.second;
@@ -2252,7 +2252,7 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
 
           if (!inputs[TEXCOORD].empty())
           {
-            for (auto pair: texcoordsOffsetToSet)
+            for (auto &pair : texcoordsOffsetToSet)
             {
               unsigned int offset = pair.first;
               unsigned int set = pair.second;
@@ -2491,7 +2491,7 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
           if (hasTexcoords)
           {
             texEqual = true;
-            for (auto pair: texcoordsOffsetToSet)
+            for (auto &pair : texcoordsOffsetToSet)
             {
               unsigned int offset = pair.first;
               unsigned int set = pair.second;
@@ -2575,7 +2575,7 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
       }
       if (hasTexcoords)
       {
-        for (auto pair: texcoordsOffsetToSet)
+        for (auto &pair : texcoordsOffsetToSet)
         {
           unsigned int offset = pair.first;
           unsigned int set = pair.second;

--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -1998,7 +1998,7 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
   std::vector<ignition::math::Vector3d> verts;
   std::vector<ignition::math::Vector3d> norms;
   std::map<unsigned int, std::vector<ignition::math::Vector2d>> texcoords;
-  std::map<unsigned int, unsigned int> texcoordsOffsetToSet;
+  std::vector<std::pair<unsigned int, unsigned int>> texcoordsOffsetToSet;
 
   const unsigned int VERTEX = 0;
   const unsigned int NORMAL = 1;
@@ -2042,16 +2042,13 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
     else if (semantic == "TEXCOORD")
     {
       int offsetInt = ignition::math::parseInt(offset);
-      if (inputs[TEXCOORD].find(offsetInt) == inputs[TEXCOORD].end())
-      {
-        unsigned int set = 0u;
-        auto setStr = polylistInputXml->Attribute("set");
-        if (setStr)
-          set = ignition::math::parseInt(setStr);
-        this->LoadTexCoords(source, texcoords[set], texDupMap[set]);
-        inputs[TEXCOORD].insert(offsetInt);
-        texcoordsOffsetToSet[offsetInt] = set;
-      }
+      unsigned int set = 0u;
+      auto setStr = polylistInputXml->Attribute("set");
+      if (setStr)
+        set = ignition::math::parseInt(setStr);
+      this->LoadTexCoords(source, texcoords[set], texDupMap[set]);
+      inputs[TEXCOORD].insert(offsetInt);
+      texcoordsOffsetToSet.push_back(std::make_pair(offsetInt, set));
     }
     else
     {
@@ -2170,9 +2167,10 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
               if (!inputs[TEXCOORD].empty())
               {
                 texEqual = true;
-                for (auto offset : inputs[TEXCOORD])
+                for (auto pair: texcoordsOffsetToSet)
                 {
-                  int set = texcoordsOffsetToSet[offset];
+                  unsigned int offset = pair.first;
+                  unsigned int set = pair.second;
                   // Get the vertex texcoord index value. If the texcoord is a
                   // duplicate then reset the index to the first instance of the
                   // duplicated texcoord
@@ -2254,12 +2252,13 @@ void ColladaLoaderPrivate::LoadPolylist(tinyxml2::XMLElement *_polylistXml,
 
           if (!inputs[TEXCOORD].empty())
           {
-            for (auto offset : inputs[TEXCOORD])
+            for (auto pair: texcoordsOffsetToSet)
             {
+              unsigned int offset = pair.first;
+              unsigned int set = pair.second;
+
               unsigned int inputRemappedTexcoordIndex =
                 values[offset];
-
-              int set = texcoordsOffsetToSet[offset];
 
               auto &texDupMapSet = texDupMap[set];
               auto texDupMapSetIt = texDupMapSet.find(
@@ -2327,7 +2326,7 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
   std::vector<ignition::math::Vector3d> verts;
   std::vector<ignition::math::Vector3d> norms;
   std::map<unsigned int, std::vector<ignition::math::Vector2d>> texcoords;
-  std::map<unsigned int, unsigned int> texcoordsOffsetToSet;
+  std::vector<std::pair<unsigned int, unsigned int>> texcoordsOffsetToSet;
 
   const unsigned int VERTEX = 0;
   const unsigned int NORMAL = 1;
@@ -2373,16 +2372,13 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
     else if (semantic == "TEXCOORD")
     {
       int offsetInt = ignition::math::parseInt(offset);
-      if (inputs[TEXCOORD].find(offsetInt) == inputs[TEXCOORD].end())
-      {
-        unsigned int set = 0u;
-        auto setStr = trianglesInputXml->Attribute("set");
-        if (setStr)
-          set = ignition::math::parseInt(setStr);
-        this->LoadTexCoords(source, texcoords[set], texDupMap[set]);
-        inputs[TEXCOORD].insert(offsetInt);
-        texcoordsOffsetToSet[offsetInt] = set;
-      }
+      unsigned int set = 0u;
+      auto setStr = trianglesInputXml->Attribute("set");
+      if (setStr)
+        set = ignition::math::parseInt(setStr);
+      this->LoadTexCoords(source, texcoords[set], texDupMap[set]);
+      inputs[TEXCOORD].insert(offsetInt);
+      texcoordsOffsetToSet.push_back(std::make_pair(offsetInt, set));
       hasTexcoords = true;
     }
     else
@@ -2495,14 +2491,16 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
           if (hasTexcoords)
           {
             texEqual = true;
-            for (auto offset : inputs[TEXCOORD])
+            for (auto pair: texcoordsOffsetToSet)
             {
+              unsigned int offset = pair.first;
+              unsigned int set = pair.second;
+
               // Get the vertex texcoord index value. If the texcoord is a
               // duplicate then reset the index to the first instance of the
               // duplicated texcoord
               unsigned int remappedTexcoordIndex =
                   values.at(offset);
-              int set = texcoordsOffsetToSet[offset];
               auto &texDupMapSet = texDupMap[set];
               auto texDupMapSetIt = texDupMapSet.find(remappedTexcoordIndex);
               if (texDupMapSetIt != texDupMapSet.end())
@@ -2577,12 +2575,14 @@ void ColladaLoaderPrivate::LoadTriangles(tinyxml2::XMLElement *_trianglesXml,
       }
       if (hasTexcoords)
       {
-        for (auto offset : inputs[TEXCOORD])
+        for (auto pair: texcoordsOffsetToSet)
         {
+          unsigned int offset = pair.first;
+          unsigned int set = pair.second;
+
           unsigned int inputRemappedTexcoordIndex =
               values.at(offset);
 
-          int set = texcoordsOffsetToSet[offset];
           auto &texDupMapSet = texDupMap[set];
           auto texDupMapSetIt = texDupMapSet.find(inputRemappedTexcoordIndex);
           if (texDupMapSetIt != texDupMapSet.end())

--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -229,7 +229,7 @@ TEST_F(ColladaLoader, TexCoordSets)
   EXPECT_FALSE(subMeshB->HasTexCoord(3u));
 
   // test texture coordinate set API
-  EXPECT_EQ(2u, subMeshB->TexCoordSetCount());
+  EXPECT_EQ(3u, subMeshB->TexCoordSetCount());
   EXPECT_EQ(3u, subMeshB->TexCoordCountBySet(0u));
   EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(0u, 0u));
   EXPECT_EQ(math::Vector2d(0, 1), subMeshB->TexCoordBySet(1u, 0u));
@@ -251,6 +251,16 @@ TEST_F(ColladaLoader, TexCoordSets)
   EXPECT_TRUE(subMeshB->HasTexCoordBySet(1u, 1u));
   EXPECT_TRUE(subMeshB->HasTexCoordBySet(2u, 1u));
   EXPECT_FALSE(subMeshB->HasTexCoordBySet(3u, 1u));
+
+  EXPECT_EQ(3u, subMeshB->TexCoordCountBySet(2u));
+  EXPECT_EQ(math::Vector2d(0, 0.8), subMeshB->TexCoordBySet(0u, 2u));
+  EXPECT_EQ(math::Vector2d(0, 0.7), subMeshB->TexCoordBySet(1u, 2u));
+  EXPECT_EQ(math::Vector2d(0, 0.6), subMeshB->TexCoordBySet(2u, 2u));
+
+  EXPECT_TRUE(subMeshB->HasTexCoordBySet(0u, 2u));
+  EXPECT_TRUE(subMeshB->HasTexCoordBySet(1u, 2u));
+  EXPECT_TRUE(subMeshB->HasTexCoordBySet(2u, 2u));
+  EXPECT_FALSE(subMeshB->HasTexCoordBySet(3u, 2u));
 
   subMeshB->SetTexCoordBySet(2u, math::Vector2d(0.1, 0.2), 1u);
   EXPECT_EQ(math::Vector2d(0.1, 0.2), subMeshB->TexCoordBySet(2u, 1u));

--- a/test/data/multiple_texture_coordinates_triangle.dae
+++ b/test/data/multiple_texture_coordinates_triangle.dae
@@ -113,6 +113,15 @@
             </accessor>
           </technique_common>
         </source>
+        <source id="triangle-mesh-b-map-2">
+          <float_array id="triangle-mesh-b-map-2-array" count="6">0 0.2 0 0.3 0 0.4</float_array>
+          <technique_common>
+            <accessor source="#triangle-mesh-b-map-2-array" count="3" stride="2">
+              <param name="S" type="float"/>
+              <param name="T" type="float"/>
+            </accessor>
+          </technique_common>
+        </source>
         <vertices id="triangle-mesh-b-vertices">
           <input semantic="POSITION" source="#triangle-mesh-b-positions"/>
         </vertices>
@@ -121,6 +130,7 @@
           <input semantic="NORMAL" source="#triangle-mesh-b-normals" offset="1"/>
           <input semantic="TEXCOORD" source="#triangle-mesh-b-map-0" offset="2" set="0"/>
           <input semantic="TEXCOORD" source="#triangle-mesh-b-map-1" offset="3" set="1"/>
+          <input semantic="TEXCOORD" source="#triangle-mesh-b-map-2" offset="3" set="2"/>
           <p>0 0 0 0 1 0 1 1 2 0 2 2</p>
         </triangles>
       </mesh>


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

When loading texture coordinates, there was an assumption in the ColladaLoader that the `offset` values (which specify the index in which the uv coordinates should be read from) need to be unique. This is found that be incorrect assumption after looking at Collada 1.5 spec ([link](https://www.khronos.org/files/collada_spec_1_5.pdf) to pdf. There is an example on page 89). 

This PR updates the loader to support loading duplicate `offset` values.

One way to test this is to use Edifice. You'll need to use this ign-common4 branch: `collada_texcoord_offset_4`, and launch a world in ign-gazebo with this [model](https://github.com/ignitionrobotics/ign-common/files/6401985/WheelChairUnfolded.zip) (zip file). Without this change, the light map is rendered incorrectly on the model and it'll appear all white. With this fix, the model should have right textures but with some subtle difference in shading.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

