### PR TITLE
Fix join paths to remove duplicate separators

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -266,7 +266,7 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   // std::string path1 = checkWindowsPath(_path1);
   // std::string path2 = checkWindowsPath(_path2);
   // +1 for directory separator, +1 for the ending \0 character
-  std::regex reg("(\\)+");
+  std::regex reg("\\\\+");
   std::vector<CHAR> combined(_path1.length() + _path2.length() + 2);
   // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
   if (::PathCombineA(combined.data(), _path1.c_str(), _path2.c_str()) != NULL)

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -266,12 +266,10 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   // std::string path1 = checkWindowsPath(_path1);
   // std::string path2 = checkWindowsPath(_path2);
   // +1 for directory separator, +1 for the ending \0 character
-  std::regex reg("\\+");
-  std::string path1 = std::regex_replace(_path1, reg, "\\");
-  std::string path2 = std::regex_replace(_path2, reg, "\\");
-  std::vector<CHAR> combined(path1.length() + path2.length() + 2);
+  std::regex reg("(\\)+");
+  std::vector<CHAR> combined(_path1.length() + _path2.length() + 2);
   // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
-  if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
+  if (::PathCombineA(combined.data(), _path1.c_str(), _path2.c_str()) != NULL)
   {
     path = std::regex_replace(
         checkWindowsPath(std::string(combined.data())), reg, "\\");
@@ -279,7 +277,7 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   else
   {
     path = std::regex_replace(
-        checkWindowsPath(separator(path1) + path2), reg, "\\");
+        checkWindowsPath(separator(_path1) + _path2), reg, "\\");
   }
 #endif  // _WIN32
   return path;

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -258,31 +258,17 @@ std::string ignition::common::joinPaths(const std::string &_path1,
                                         const std::string &_path2)
 {
   // avoid duplicated '/' at the beginning/end of the string
-  auto sanitizeSlashes = [](const std::string &_path, bool is_windows = false)
-  {
-    std::string result = _path;
-    if (is_windows && !result.empty() &&
-      (result[0] == '\\' || result[0] == '/'))
-    {
-        result.erase(0, 1);
-    }
-    if (!result.empty() &&
-      (result[result.length()-1] == '/' || result[result.length()-1] == '\\'))
-    {
-        result.erase(result.length()-1, 1);
-    }
-    return result;
-  };
   std::string path;
 #ifndef _WIN32
-  path = sanitizeSlashes(separator(sanitizeSlashes(_path1))
-    + sanitizeSlashes(_path2));
+  std::regex reg("/+");
+  path = std::regex_replace(separator(_path1) + _path2, reg, "/");
 #else  // _WIN32
   // std::string path1 = checkWindowsPath(_path1);
   // std::string path2 = checkWindowsPath(_path2);
   // +1 for directory separator, +1 for the ending \0 character
-  std::string path1 = sanitizeSlashes(_path1, true);
-  std::string path2 = sanitizeSlashes(_path2, true);
+  std::regex reg("\\+");
+  std::string path1 = std::regex_replace(_path1, reg, "\\");
+  std::string path2 = std::regex_replace(_path2, reg, "\\");
   std::vector<CHAR> combined(path1.length() + path2.length() + 2);
   // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
   if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -272,9 +272,15 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   std::vector<CHAR> combined(path1.length() + path2.length() + 2);
   // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
   if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
-    path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
+  {
+    path = std::regex_replace(
+        checkWindowsPath(std::string(combined.data())), reg, "\\");
+  }
   else
-    path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
+  {
+    path = std::regex_replace(
+        checkWindowsPath(separator(path1) + path2), reg, "\\");
+  }
 #endif  // _WIN32
   return path;
 }

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -417,14 +417,14 @@ TEST_F(FilesystemTest, append)
   EXPECT_EQ(path, "base\\before\\after\\");
 #endif
 
-  path = joinPaths("base", "/before", "after//");
+  path = joinPaths("base", "/before", "after///");
 #ifndef _WIN32
   EXPECT_EQ(path, "base/before/after/");
 #else
   EXPECT_EQ(path, "base\\before\\after\\");
 #endif
 
-  path = joinPaths("//base", "/before", "after");
+  path = joinPaths("///base", "/before", "after");
 #ifndef _WIN32
   EXPECT_EQ(path, "/base/before/after");
 #else
@@ -438,7 +438,7 @@ TEST_F(FilesystemTest, append)
   EXPECT_EQ(path, "\\base\\before\\after");
 #endif
 
-  path = joinPaths("//base", "/before", "after//");
+  path = joinPaths("///base", "///before//", "/after///");
 #ifndef _WIN32
   EXPECT_EQ(path, "/base/before/after/");
 #else

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -412,7 +412,42 @@ TEST_F(FilesystemTest, append)
   path = joinPaths("base", "/before", "after/");
 
 #ifndef _WIN32
-  EXPECT_EQ(path, "base//before/after");
+  EXPECT_EQ(path, "base/before/after/");
+#else
+  EXPECT_EQ(path, "base\\before\\after\\");
+#endif
+
+  path = joinPaths("base", "/before", "after//");
+#ifndef _WIN32
+  EXPECT_EQ(path, "base/before/after/");
+#else
+  EXPECT_EQ(path, "base\\before\\after\\");
+#endif
+
+  path = joinPaths("//base", "/before", "after");
+#ifndef _WIN32
+  EXPECT_EQ(path, "/base/before/after");
+#else
+  EXPECT_EQ(path, "\\base\\before\\after");
+#endif
+
+  path = joinPaths("/base", "/before", "after");
+#ifndef _WIN32
+  EXPECT_EQ(path, "/base/before/after");
+#else
+  EXPECT_EQ(path, "\\base\\before\\after");
+#endif
+
+  path = joinPaths("//base", "/before", "after//");
+#ifndef _WIN32
+  EXPECT_EQ(path, "/base/before/after/");
+#else
+  EXPECT_EQ(path, "\\base\\before\\after\\");
+#endif
+
+  path = joinPaths("base", "/before", "after");
+#ifndef _WIN32
+  EXPECT_EQ(path, "base/before/after");
 #else
   EXPECT_EQ(path, "base\\before\\after");
 #endif


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

The `joinPaths` function would remove trailing slashes from the function arguments. This can cause downstream applications, like fuel tools using libzip, to treat a directory as a file.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers
