### PR TITLE
Fix join paths again

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -257,28 +257,60 @@ std::string checkWindowsPath(const std::string _path)
 std::string ignition::common::joinPaths(const std::string &_path1,
                                         const std::string &_path2)
 {
-  // avoid duplicated '/' at the beginning/end of the string
+
+  /// This function is used to avoid duplicated path separators at the
+  /// beginning/end of the string, and between the two paths being joined.
+  /// \param[in] _path This is the string to sanitize.
+  /// \param[in] _stripLeading True if the leading separator should be
+  /// removed.
+  auto sanitizeSlashes = [](const std::string &_path,
+                            bool _stripLeading = false)
+  {
+    // Shortcut
+    if (_path.empty())
+      return _path;
+
+    std::string result = _path;
+
+    // Use the appropriate character for each platform.
+#ifndef _WIN32
+    char replacement = '/';
+#else
+    char replacement = '\\';
+#endif
+
+    // Sanitize the start of the path.
+    size_t index = 0;
+    size_t leadingIndex = _stripLeading ? 0 : 1;
+    for (; result[index] == replacement; ++index)
+    {
+    }
+    if (index > leadingIndex)
+      result.erase(leadingIndex, index-leadingIndex);
+
+    // Sanitize the end of the path.
+    index = result.length()-1;
+    for (; result[index] == replacement; --index)
+    {
+    }
+    index += 1;
+    if (index < result.length()-1)
+        result.erase(index+1);
+    return result;
+  };
+
   std::string path;
 #ifndef _WIN32
-  std::regex reg("/+");
-  path = std::regex_replace(separator(_path1) + _path2, reg, "/");
+  path = sanitizeSlashes(sanitizeSlashes(separator(_path1)) +
+      sanitizeSlashes(_path2, true));
 #else  // _WIN32
-  // std::string path1 = checkWindowsPath(_path1);
-  // std::string path2 = checkWindowsPath(_path2);
-  // +1 for directory separator, +1 for the ending \0 character
-  std::regex reg("\\\\+");
-  std::vector<CHAR> combined(_path1.length() + _path2.length() + 2);
-  // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
-  if (::PathCombineA(combined.data(), _path1.c_str(), _path2.c_str()) != NULL)
-  {
-    path = std::regex_replace(
-        checkWindowsPath(std::string(combined.data())), reg, "\\");
-  }
+  std::string path1 = sanitizeSlashes(_path1);
+  std::string path2 = sanitizeSlashes(_path2, true);
+  std::vector<CHAR> combined(path1.length() + path2.length() + 2);
+  if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
+    path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
   else
-  {
-    path = std::regex_replace(
-        checkWindowsPath(separator(_path1) + _path2), reg, "\\");
-  }
+    path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
 #endif  // _WIN32
   return path;
 }

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -304,19 +304,16 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   path = sanitizeSlashes(sanitizeSlashes(separator(_path1)) +
       sanitizeSlashes(_path2, true));
 #else  // _WIN32
-  std::string path1 = sanitizeSlashes(_path1);
-  std::string path2 = sanitizeSlashes(_path2, true);
+  std::string path1 = sanitizeSlashes(checkWindowsPath(_path1));
+  std::string path2 = sanitizeSlashes(checkWindowsPath(_path2), true);
   std::vector<CHAR> combined(path1.length() + path2.length() + 2);
-  std::cout << "\n\n HERE. PATH1[" << path1 << "] PATH2[" << path2 << "]\n";
   if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
   {
     path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
-    std::cout << "\n\n HERE1[" << path << "]\n";
   }
   else
   {
     path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
-    std::cout << "\n\n HERE2[" << path << "]\n";
   }
 #endif  // _WIN32
   return path;

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -307,10 +307,17 @@ std::string ignition::common::joinPaths(const std::string &_path1,
   std::string path1 = sanitizeSlashes(_path1);
   std::string path2 = sanitizeSlashes(_path2, true);
   std::vector<CHAR> combined(path1.length() + path2.length() + 2);
+  std::cout << "\n\n HERE. PATH1[" << path1 << "] PATH2[" << path2 << "]\n";
   if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
+  {
     path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
+    std::cout << "\n\n HERE1[" << path << "]\n";
+  }
   else
+  {
     path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
+    std::cout << "\n\n HERE2[" << path << "]\n";
+  }
 #endif  // _WIN32
   return path;
 }

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -451,6 +451,15 @@ TEST_F(FilesystemTest, append)
 #else
   EXPECT_EQ(path, "base\\before\\after");
 #endif
+
+  // Make sure that the slashes in the middle of string are not altered.
+  path = joinPaths("https://fuel.ignitionrobotics.org", "/models", "box");
+#ifndef _WIN32
+  EXPECT_EQ(path, "https://fuel.ignitionrobotics.org/models/box");
+#else
+  EXPECT_EQ(path, "https:\\\\fuel.ignitionrobotics.org\\models\\box");
+#endif
+
 }
 
 /////////////////////////////////////////////////

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -454,12 +454,7 @@ TEST_F(FilesystemTest, append)
 
   // Make sure that the slashes in the middle of string are not altered.
   path = joinPaths("https://fuel.ignitionrobotics.org", "/models", "box");
-#ifndef _WIN32
   EXPECT_EQ(path, "https://fuel.ignitionrobotics.org/models/box");
-#else
-  EXPECT_EQ(path, "https:\\\\fuel.ignitionrobotics.org\\models\\box");
-#endif
-
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

PR #209 broke a different part of fuel-tools, this time in [ModelIdentifier](https://github.com/ignitionrobotics/ign-fuel-tools/blob/ign-fuel-tools5/src/ModelIdentifier.cc#L146). Strings with `https://server` would become `https:/server`. Note the missing second slash. This is an invalid URI.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**