### PR TITLE
Revert "Fix join paths to remove duplicate separators"

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -258,27 +258,37 @@ std::string ignition::common::joinPaths(const std::string &_path1,
                                         const std::string &_path2)
 {
   // avoid duplicated '/' at the beginning/end of the string
+  auto sanitizeSlashes = [](const std::string &_path, bool is_windows = false)
+  {
+    std::string result = _path;
+    if (is_windows && !result.empty() &&
+      (result[0] == '\\' || result[0] == '/'))
+    {
+        result.erase(0, 1);
+    }
+    if (!result.empty() &&
+      (result[result.length()-1] == '/' || result[result.length()-1] == '\\'))
+    {
+        result.erase(result.length()-1, 1);
+    }
+    return result;
+  };
   std::string path;
 #ifndef _WIN32
-  std::regex reg("/+");
-  path = std::regex_replace(separator(_path1) + _path2, reg, "/");
+  path = sanitizeSlashes(separator(sanitizeSlashes(_path1))
+    + sanitizeSlashes(_path2));
 #else  // _WIN32
   // std::string path1 = checkWindowsPath(_path1);
   // std::string path2 = checkWindowsPath(_path2);
   // +1 for directory separator, +1 for the ending \0 character
-  std::regex reg("\\\\+");
-  std::vector<CHAR> combined(_path1.length() + _path2.length() + 2);
+  std::string path1 = sanitizeSlashes(_path1, true);
+  std::string path2 = sanitizeSlashes(_path2, true);
+  std::vector<CHAR> combined(path1.length() + path2.length() + 2);
   // TODO(anyone): Switch to PathAllocCombine once switched to wide strings
-  if (::PathCombineA(combined.data(), _path1.c_str(), _path2.c_str()) != NULL)
-  {
-    path = std::regex_replace(
-        checkWindowsPath(std::string(combined.data())), reg, "\\");
-  }
+  if (::PathCombineA(combined.data(), path1.c_str(), path2.c_str()) != NULL)
+    path = sanitizeSlashes(checkWindowsPath(std::string(combined.data())));
   else
-  {
-    path = std::regex_replace(
-        checkWindowsPath(separator(_path1) + _path2), reg, "\\");
-  }
+    path = sanitizeSlashes(checkWindowsPath(separator(path1) + path2));
 #endif  // _WIN32
   return path;
 }

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -412,42 +412,7 @@ TEST_F(FilesystemTest, append)
   path = joinPaths("base", "/before", "after/");
 
 #ifndef _WIN32
-  EXPECT_EQ(path, "base/before/after/");
-#else
-  EXPECT_EQ(path, "base\\before\\after\\");
-#endif
-
-  path = joinPaths("base", "/before", "after///");
-#ifndef _WIN32
-  EXPECT_EQ(path, "base/before/after/");
-#else
-  EXPECT_EQ(path, "base\\before\\after\\");
-#endif
-
-  path = joinPaths("///base", "/before", "after");
-#ifndef _WIN32
-  EXPECT_EQ(path, "/base/before/after");
-#else
-  EXPECT_EQ(path, "\\base\\before\\after");
-#endif
-
-  path = joinPaths("/base", "/before", "after");
-#ifndef _WIN32
-  EXPECT_EQ(path, "/base/before/after");
-#else
-  EXPECT_EQ(path, "\\base\\before\\after");
-#endif
-
-  path = joinPaths("///base", "///before//", "/after///");
-#ifndef _WIN32
-  EXPECT_EQ(path, "/base/before/after/");
-#else
-  EXPECT_EQ(path, "\\base\\before\\after\\");
-#endif
-
-  path = joinPaths("base", "/before", "after");
-#ifndef _WIN32
-  EXPECT_EQ(path, "base/before/after");
+  EXPECT_EQ(path, "base//before/after");
 #else
   EXPECT_EQ(path, "base\\before\\after");
 #endif


### PR DESCRIPTION
Rather than landing https://github.com/ignitionrobotics/ign-common/pull/215, I believe the correct thing is to revert #209, perform a release, and then get https://github.com/ignitionrobotics/ign-fuel-tools/pull/178 landed, which should resolve the issues that we seeing (https://github.com/ignitionrobotics/ign-fuel-tools/issues/183)

Reverts ignitionrobotics/ign-common#209