### PR TITLE
Export lights to dae

### DIFF
--- a/graphics/include/ignition/common/ColladaExporter.hh
+++ b/graphics/include/ignition/common/ColladaExporter.hh
@@ -38,7 +38,7 @@ namespace ignition
     struct ColladaLight
     {
       std::string name;
-      std::string type; //either "point", "directional" or "spot"
+      std::string type;  // either "point", "directional" or "spot"
       math::Vector3d direction;
       math::Vector3d position;
       math::Color diffuse;
@@ -69,7 +69,8 @@ namespace ignition
       public: void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures,
           const std::vector<math::Matrix4d> &_submeshToMatrix,
-          const std::vector<ColladaLight> &_lights = std::vector<ColladaLight>());
+          const std::vector<ColladaLight> &_lights =
+            std::vector<ColladaLight>());
 
       /// \brief Pointer to private data.
       IGN_UTILS_IMPL_PTR(dataPtr)

--- a/graphics/include/ignition/common/ColladaExporter.hh
+++ b/graphics/include/ignition/common/ColladaExporter.hh
@@ -37,16 +37,35 @@ namespace ignition
     /// Defaults set based on collada 1.4 specifications
     struct ColladaLight
     {
-      std::string name;  // name of the light
-      std::string type;  // either "point", "directional" or "spot"
-      math::Vector3d direction;  // direction (directional/spot lights only)
-      math::Vector3d position;  // light position (non directional lights only)
-      math::Color diffuse;  // light diffuse color
-      double constant_attenuation = 1.0;  // Constant attentuation
-      double linear_attenuation = 0.0;  // Linear attentuation
-      double quadratic_attenuation = 0.0;  // Quadratic attentuation
-      double falloff_angle_deg = 180.0;  // Falloff angle in degrees
-      double falloff_exponent = 0.0;  // Fallof exponent
+      /// \brief Name of the light
+      std::string name;
+
+      /// \brief Type of the light. Either "point", "directional" or "spot"
+      std::string type;
+
+      /// \brief Light direction (directional/spot lights only)
+      math::Vector3d direction;
+
+      /// \brief Light position (non directional lights only)
+      math::Vector3d position;
+
+      /// \brief Light diffuse color
+      math::Color diffuse;
+
+      /// \brief Constant attentuation
+      double constantAttenuation = 1.0;
+
+      /// \brief Linear attentuation
+      double linearAttenuation = 0.0;
+
+      /// \brief Quadratic attentuation
+      double quadraticAttenuation = 0.0;
+
+      /// \brief Falloff angle in degrees
+      double falloffAngleDeg = 180.0;
+
+      /// \brief Fallof exponent
+      double falloffExponent = 0.0;
     };
 
     /// \brief Class used to export Collada mesh files
@@ -66,10 +85,23 @@ namespace ignition
       public: virtual void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures = false);
 
+      /// \brief Export a mesh to a file
+      /// \param[in] _mesh Pointer to the mesh to be exported
+      /// \param[in] _filename Exported file's path and name
+      /// \param[in] _exportTextures True to export texture images to
+      /// '../materials/textures' folder
+      /// \param[in] _submeshToMatrix Matrices of submeshes
       public: void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures,
           const std::vector<math::Matrix4d> &_submeshToMatrix);
 
+      /// \brief Export a mesh to a file
+      /// \param[in] _mesh Pointer to the mesh to be exported
+      /// \param[in] _filename Exported file's path and name
+      /// \param[in] _exportTextures True to export texture images to
+      /// '../materials/textures' folder
+      /// \param[in] _submeshToMatrix Matrices of submeshes
+      /// \param[in] _lights List of lights to export
       public: void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures,
           const std::vector<math::Matrix4d> &_submeshToMatrix,

--- a/graphics/include/ignition/common/ColladaExporter.hh
+++ b/graphics/include/ignition/common/ColladaExporter.hh
@@ -24,8 +24,8 @@
 #include <ignition/common/MeshExporter.hh>
 #include <ignition/common/graphics/Export.hh>
 
-#include <ignition/math/Matrix4.hh>
 #include <ignition/math/Color.hh>
+#include <ignition/math/Matrix4.hh>
 
 #include <ignition/utils/ImplPtr.hh>
 
@@ -33,20 +33,20 @@ namespace ignition
 {
   namespace common
   {
-    // Light data structure specifically for collada export
-    // Defaults set based on collada 1.4 specifications
+    /// \brief This struct contains light data specifically for collada export
+    /// Defaults set based on collada 1.4 specifications
     struct ColladaLight
     {
-      std::string name;
+      std::string name;  // name of the light
       std::string type;  // either "point", "directional" or "spot"
-      math::Vector3d direction;
-      math::Vector3d position;
-      math::Color diffuse;
-      double constant_attenuation = 1.0;
-      double linear_attenuation   = 0.0;
-      double quadratic_attenuation = 0.0;
-      double falloff_angle_deg = 180.0;
-      double falloff_exponent = 0.0;
+      math::Vector3d direction;  // direction (directional/spot lights only)
+      math::Vector3d position;  // light position (non directional lights only)
+      math::Color diffuse;  // light diffuse color
+      double constant_attenuation = 1.0;  // Constant attentuation
+      double linear_attenuation = 0.0;  // Linear attentuation
+      double quadratic_attenuation = 0.0;  // Quadratic attentuation
+      double falloff_angle_deg = 180.0;  // Falloff angle in degrees
+      double falloff_exponent = 0.0;  // Fallof exponent
     };
 
     /// \brief Class used to export Collada mesh files

--- a/graphics/include/ignition/common/ColladaExporter.hh
+++ b/graphics/include/ignition/common/ColladaExporter.hh
@@ -25,6 +25,7 @@
 #include <ignition/common/graphics/Export.hh>
 
 #include <ignition/math/Matrix4.hh>
+#include <ignition/math/Color.hh>
 
 #include <ignition/utils/ImplPtr.hh>
 
@@ -32,6 +33,22 @@ namespace ignition
 {
   namespace common
   {
+    // Light data structure specifically for collada export
+    // Defaults set based on collada 1.4 specifications
+    struct ColladaLight
+    {
+      std::string name;
+      std::string type; //either "point", "directional" or "spot"
+      math::Vector3d direction;
+      math::Vector3d position;
+      math::Color diffuse;
+      double constant_attenuation = 1.0;
+      double linear_attenuation   = 0.0;
+      double quadratic_attenuation = 0.0;
+      double falloff_angle_deg = 180.0;
+      double falloff_exponent = 0.0;
+    };
+
     /// \brief Class used to export Collada mesh files
     class IGNITION_COMMON_GRAPHICS_VISIBLE ColladaExporter : public MeshExporter
     {
@@ -51,7 +68,8 @@ namespace ignition
 
       public: void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures,
-          const std::vector<math::Matrix4d> &_submeshToMatrix);
+          const std::vector<math::Matrix4d> &_submeshToMatrix,
+          const std::vector<ColladaLight> &_lights = std::vector<ColladaLight>());
 
       /// \brief Pointer to private data.
       IGN_UTILS_IMPL_PTR(dataPtr)

--- a/graphics/include/ignition/common/ColladaExporter.hh
+++ b/graphics/include/ignition/common/ColladaExporter.hh
@@ -68,9 +68,12 @@ namespace ignition
 
       public: void Export(const Mesh *_mesh,
           const std::string &_filename, bool _exportTextures,
+          const std::vector<math::Matrix4d> &_submeshToMatrix);
+
+      public: void Export(const Mesh *_mesh,
+          const std::string &_filename, bool _exportTextures,
           const std::vector<math::Matrix4d> &_submeshToMatrix,
-          const std::vector<ColladaLight> &_lights =
-            std::vector<ColladaLight>());
+          const std::vector<ColladaLight> &_lights);
 
       /// \brief Pointer to private data.
       IGN_UTILS_IMPL_PTR(dataPtr)

--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -255,7 +255,7 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
     tinyxml2::XMLElement *techniqueCommonXml =
       xmlDoc.NewElement("technique_common");
     lightXml->LinkEndChild(techniqueCommonXml);
-    
+
     tinyxml2::XMLElement *lightTypeXml =
       xmlDoc.NewElement(light.type.c_str());
     techniqueCommonXml->LinkEndChild(lightTypeXml);
@@ -264,7 +264,8 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
     tinyxml2::XMLElement *colorXml =
       xmlDoc.NewElement("color");
     char color_str[100] = { 0 };
-    snprintf(color_str, sizeof(color_str), "%g %g %g", light.diffuse.R(), light.diffuse.G(), light.diffuse.B());
+    snprintf(color_str, sizeof(color_str), "%g %g %g",
+      light.diffuse.R(), light.diffuse.G(), light.diffuse.B());
     colorXml->SetText(color_str);
     lightTypeXml->LinkEndChild(colorXml);
 
@@ -275,7 +276,7 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
       {
         tinyxml2::XMLElement *attenXml =
           xmlDoc.NewElement(tagname);
-        
+
         char str[100] = { 0 };
         snprintf(str, sizeof(str), "%g", value);
         attenXml->SetText(str);
@@ -308,7 +309,8 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
   // Library visual scenes element
   tinyxml2::XMLElement *libraryVisualScenesXml =
       xmlDoc.NewElement("library_visual_scenes");
-  this->dataPtr->ExportVisualScenes(libraryVisualScenesXml, _submeshToMatrix, _lights);
+  this->dataPtr->ExportVisualScenes(libraryVisualScenesXml,
+    _submeshToMatrix, _lights);
   colladaXml->LinkEndChild(libraryVisualScenesXml);
 
   // Scene element
@@ -939,7 +941,8 @@ void ColladaExporter::Implementation::ExportVisualScenes(
       translateXml->SetAttribute("sid", "translate");
 
       char tx_value[100] = { 0 };
-      snprintf(tx_value, sizeof(tx_value), "%f %f %f", position.X(), position.Y(), position.Z());
+      snprintf(tx_value, sizeof(tx_value), "%f %f %f",
+        position.X(), position.Y(), position.Z());
       translateXml->SetText(tx_value);
       nodeXml->LinkEndChild(translateXml);
     }
@@ -960,7 +963,8 @@ void ColladaExporter::Implementation::ExportVisualScenes(
         _libraryVisualScenesXml->GetDocument()->NewElement("rotate");
 
       char str[100] = { 0 };
-      snprintf(str, sizeof(str), "%g %g %g %g", axis.X(), axis.Y(), axis.Z(), angle / IGN_PI * 180.0);
+      snprintf(str, sizeof(str), "%g %g %g %g",
+        axis.X(), axis.Y(), axis.Z(), angle / IGN_PI * 180.0);
       rotateXml->SetText(str);
       nodeXml->LinkEndChild(rotateXml);
     }

--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -269,7 +269,7 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
     lightTypeXml->LinkEndChild(colorXml);
 
     // attenuations
-    if (light.name == "point" || light.name == "spot")
+    if (light.type == "point" || light.type == "spot")
     {
       auto attenuation_tag = [&](const char* tagname, double value)
       {
@@ -287,7 +287,7 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
     }
 
     // falloff
-    if (light.name == "spot")
+    if (light.type == "spot")
     {
       tinyxml2::XMLElement *falloffAngleXml =
         xmlDoc.NewElement("falloff_angle");
@@ -297,7 +297,7 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
       lightTypeXml->LinkEndChild(falloffAngleXml);
 
       tinyxml2::XMLElement *falloffExpoXml =
-        xmlDoc.NewElement("falloff_angle");
+        xmlDoc.NewElement("falloff_exponent");
       snprintf(str, sizeof(str), "%g", light.falloff_exponent);
       falloffExpoXml->SetText(str);
       lightTypeXml->LinkEndChild(falloffExpoXml);

--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -292,9 +292,9 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
         attenXml->SetText(str);
         lightTypeXml->LinkEndChild(attenXml);
       };
-      attenuation_tag("constant_attenuation", light.constant_attenuation);
-      attenuation_tag("linear_attenuation", light.linear_attenuation);
-      attenuation_tag("quadratic_attenuation", light.quadratic_attenuation);
+      attenuation_tag("constant_attenuation", light.constantAttenuation);
+      attenuation_tag("linear_attenuation", light.linearAttenuation);
+      attenuation_tag("quadratic_attenuation", light.quadraticAttenuation);
     }
 
     // falloff
@@ -303,13 +303,13 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
       tinyxml2::XMLElement *falloffAngleXml =
         xmlDoc.NewElement("falloff_angle");
       char str[100] = { 0 };
-      snprintf(str, sizeof(str), "%g", light.falloff_angle_deg);
+      snprintf(str, sizeof(str), "%g", light.falloffAngleDeg);
       falloffAngleXml->SetText(str);
       lightTypeXml->LinkEndChild(falloffAngleXml);
 
       tinyxml2::XMLElement *falloffExpoXml =
         xmlDoc.NewElement("falloff_exponent");
-      snprintf(str, sizeof(str), "%g", light.falloff_exponent);
+      snprintf(str, sizeof(str), "%g", light.falloffExponent);
       falloffExpoXml->SetText(str);
       lightTypeXml->LinkEndChild(falloffExpoXml);
     }

--- a/graphics/src/ColladaExporter.cc
+++ b/graphics/src/ColladaExporter.cc
@@ -170,6 +170,16 @@ void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
 }
 
 //////////////////////////////////////////////////
+void ColladaExporter::Export(const Mesh *_mesh,
+        const std::string &_filename, bool _exportTextures,
+        const std::vector<math::Matrix4d> &_submeshToMatrix)
+{
+  std::vector<ColladaLight> empty_lights;
+  this->Export(_mesh, _filename, _exportTextures,
+    _submeshToMatrix, empty_lights);
+}
+
+//////////////////////////////////////////////////
 void ColladaExporter::Export(const Mesh *_mesh, const std::string &_filename,
     bool _exportTextures, const std::vector<math::Matrix4d> &_submeshToMatrix,
     const std::vector<ColladaLight> &_lights)

--- a/graphics/src/ColladaExporter_TEST.cc
+++ b/graphics/src/ColladaExporter_TEST.cc
@@ -346,9 +346,9 @@ TEST_F(ColladaExporter, ExportLights)
     point.type = "point";
     point.position = math::Vector3d(0, 0, 10);
     point.diffuse = math::Color(1, 0.5, 1);
-    point.constant_attenuation = 0.8;
-    point.linear_attenuation = 0.8;
-    point.quadratic_attenuation = 0.1;
+    point.constantAttenuation = 0.8;
+    point.linearAttenuation = 0.8;
+    point.quadraticAttenuation = 0.1;
     lights.push_back(point);
 
     common::ColladaLight spot;
@@ -356,11 +356,11 @@ TEST_F(ColladaExporter, ExportLights)
     spot.type = "spot";
     spot.position = math::Vector3d(0, 10, 10);
     spot.diffuse = math::Color(1, 0.5, 1);
-    spot.constant_attenuation = 0.8;
-    spot.linear_attenuation = 0.8;
-    spot.quadratic_attenuation = 0.1;
-    spot.falloff_angle_deg = 90.0;
-    spot.falloff_exponent = 0.125;
+    spot.constantAttenuation = 0.8;
+    spot.linearAttenuation = 0.8;
+    spot.quadraticAttenuation = 0.1;
+    spot.falloffAngleDeg = 90.0;
+    spot.falloffExponent = 0.125;
     lights.push_back(spot);
   }
 
@@ -382,48 +382,35 @@ TEST_F(ColladaExporter, ExportLights)
     const char* light_name_cstr = light_ele->Attribute("name");
     ASSERT_TRUE(light_name_cstr);
     std::string light_name = light_name_cstr;
+
+    auto technique = light_ele->FirstChildElement("technique_common");
+    EXPECT_TRUE(technique);
+
     if (light_name == "sun")
     {
-      auto technique = light_ele->FirstChildElement("technique_common");
-      EXPECT_TRUE(technique);
       auto directional = technique->FirstChildElement("directional");
       EXPECT_TRUE(directional);
-      auto color = directional->FirstChildElement("color");
-      EXPECT_TRUE(color);
+      EXPECT_TRUE(directional->FirstChildElement("color"));
     }
     else if (light_name == "lamp")
     {
-      auto technique = light_ele->FirstChildElement("technique_common");
-      EXPECT_TRUE(technique);
       auto point = technique->FirstChildElement("point");
       EXPECT_TRUE(point);
-      auto color = point->FirstChildElement("color");
-      EXPECT_TRUE(color);
-      auto catt = point->FirstChildElement("constant_attenuation");
-      EXPECT_TRUE(catt);
-      auto latt = point->FirstChildElement("linear_attenuation");
-      EXPECT_TRUE(latt);
-      auto qatt = point->FirstChildElement("quadratic_attenuation");
-      EXPECT_TRUE(qatt);
+      EXPECT_TRUE(point->FirstChildElement("color"));
+      EXPECT_TRUE(point->FirstChildElement("constant_attenuation"));
+      EXPECT_TRUE(point->FirstChildElement("linear_attenuation"));
+      EXPECT_TRUE(point->FirstChildElement("quadratic_attenuation"));
     }
     else if (light_name == "torch")
     {
-      auto technique = light_ele->FirstChildElement("technique_common");
-      EXPECT_TRUE(technique);
       auto spot = technique->FirstChildElement("spot");
       EXPECT_TRUE(spot);
-      auto color = spot->FirstChildElement("color");
-      EXPECT_TRUE(color);
-      auto catt = spot->FirstChildElement("constant_attenuation");
-      EXPECT_TRUE(catt);
-      auto latt = spot->FirstChildElement("linear_attenuation");
-      EXPECT_TRUE(latt);
-      auto qatt = spot->FirstChildElement("quadratic_attenuation");
-      EXPECT_TRUE(qatt);
-      auto falloff_angle = spot->FirstChildElement("falloff_angle");
-      EXPECT_TRUE(falloff_angle);
-      auto falloff_expo = spot->FirstChildElement("falloff_exponent");
-      EXPECT_TRUE(falloff_expo);
+      EXPECT_TRUE(spot->FirstChildElement("color"));
+      EXPECT_TRUE(spot->FirstChildElement("constant_attenuation"));
+      EXPECT_TRUE(spot->FirstChildElement("linear_attenuation"));
+      EXPECT_TRUE(spot->FirstChildElement("quadratic_attenuation"));
+      EXPECT_TRUE(spot->FirstChildElement("falloff_angle"));
+      EXPECT_TRUE(spot->FirstChildElement("falloff_exponent"));
     }
     else
       ASSERT_TRUE(0);  // Invalid light name given
@@ -447,12 +434,9 @@ TEST_F(ColladaExporter, ExportLights)
     std::string node_name = node_name_cstr;
     if (node_name == "sun" || node_name == "lamp" || node_name == "torch")
     {
-      auto inst_light = node_ele->FirstChildElement("instance_light");
-      EXPECT_TRUE(inst_light);
-      auto translate = node_ele->FirstChildElement("translate");
-      EXPECT_TRUE(translate);
-      auto rotate = node_ele->FirstChildElement("rotate");
-      EXPECT_TRUE(rotate);
+      EXPECT_TRUE(node_ele->FirstChildElement("instance_light"));
+      EXPECT_TRUE(node_ele->FirstChildElement("translate"));
+      EXPECT_TRUE(node_ele->FirstChildElement("rotate"));
 
       ++node_with_light_count;
     }

--- a/graphics/src/ColladaExporter_TEST.cc
+++ b/graphics/src/ColladaExporter_TEST.cc
@@ -318,7 +318,8 @@ TEST_F(ColladaExporter, ExportMeshWithSubmeshes)
 TEST_F(ColladaExporter, ExportLights)
 {
   const auto filenameIn = common::testing::TestFile("data", "box.dae");
-  const auto filenameOut = common::joinPaths(this->pathOut, "box_with_lights_exported");
+  const auto filenameOut = common::joinPaths(this->pathOut,
+    "box_with_lights_exported");
   const auto filenameOutExt = filenameOut + ".dae";
 
   // Load original mesh
@@ -364,17 +365,17 @@ TEST_F(ColladaExporter, ExportLights)
   }
 
   exporter.Export(meshOriginal, filenameOut, false, submesh_mtx, lights);
-  
+
   tinyxml2::XMLDocument xmlDoc;
   ASSERT_EQ(xmlDoc.LoadFile(filenameOutExt.c_str()), tinyxml2::XML_SUCCESS);
-  
+
   tinyxml2::XMLElement* collada = xmlDoc.FirstChildElement("COLLADA");
   ASSERT_TRUE(xmlDoc.FirstChildElement("COLLADA") != nullptr);
 
   auto lib_lights = collada->FirstChildElement("library_lights");
   EXPECT_TRUE(lib_lights);
 
-  int light_count = 0;  
+  int light_count = 0;
   auto light_ele = lib_lights->FirstChildElement("light");
   for (; light_ele != nullptr; light_ele = light_ele->NextSiblingElement())
   {
@@ -425,7 +426,7 @@ TEST_F(ColladaExporter, ExportLights)
       EXPECT_TRUE(falloff_expo);
     }
     else
-      ASSERT_TRUE(0); // Invalid light name given
+      ASSERT_TRUE(0);  // Invalid light name given
 
     ++light_count;
   }


### PR DESCRIPTION
# 🎉 New feature

Closes [#901](https://github.com/ignitionrobotics/ign-gazebo/issues/901)

[Downstream PR](https://github.com/ignitionrobotics/ign-gazebo/pull/912)

## Summary
- Exports lights for the collada world exporter. Based off the [collada 1.4 spec](https://www.khronos.org/files/collada_spec_1_4.pdf)
- Test added for collada exporter exporting lights

## Test it
run `./build/ignition-common4/bin/UNIT_ColladaExporter_TEST`

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

