### PR TITLE
Add cstring for `std::memcpy`

### DIFF
--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -19,6 +19,7 @@
 #endif
 #include <FreeImage.h>
 
+#include <cstring>
 #include <string>
 
 #include <ignition/common/Console.hh>


### PR DESCRIPTION
## Summary

Just a simple fix for a really weird compilation error. Shouldn't have seen it, but saw it, so created a tiny PR

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
