### PR TITLE
Fix segfault caused by destruction order of Event and Connection

### DIFF
--- a/events/src/Event_TEST.cc
+++ b/events/src/Event_TEST.cc
@@ -284,6 +284,21 @@ TEST_F(EventTest, typeid_test)
 }
 
 /////////////////////////////////////////////////
+TEST_F(EventTest, DestructionOrder)
+{
+  auto evt = std::make_unique<common::EventT<void()>>();
+  common::ConnectionPtr conn = evt->Connect(callback);
+  evt->Signal();
+  evt.reset();
+  // Sleep to avoid warning about deleting a connection right after creation.
+  IGN_SLEEP_MS(1);
+
+  // Check that this doesn't segfault.
+  conn.reset();
+  SUCCEED();
+}
+
+/////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignitionrobotics/ign-gazebo/issues/906

## Summary
A segfault occurs in the destructor of `common::Connection` if the `common::Event` its associated with has already been deleted. This patch clears the `event` pointer of `common::Connection` when the associated `common::Event` is deleted. 

Another issue mentioned in https://github.com/ignitionrobotics/ign-gazebo/issues/906 is that the destructor of `std::function` crashes if the function it points to is from a shared library that has been unloaded. This is fixed by invoking the destructor as soon as `common:EventT::Disconnect` is called via `common::Connection::~Connection` since that's likely to be right before the shared library containing the `common::Connection` is unloaded.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
