### PR TITLE
Suggestion to #227: More data race fixes

### DIFF
--- a/include/ignition/common/Console.hh
+++ b/include/ignition/common/Console.hh
@@ -206,7 +206,7 @@ namespace ignition
                    /// \brief Level of verbosity
                    public: int verbosity;
 
-                   /// \brief Mutex to syncronize writes to the string buffer
+                   /// \brief Mutex to synchronize writes to the string buffer
                    /// and the output stream.
                    public: std::mutex syncMutex;
                  };

--- a/include/ignition/common/Console.hh
+++ b/include/ignition/common/Console.hh
@@ -183,6 +183,13 @@ namespace ignition
                    /// \brief Destructor.
                    public: virtual ~Buffer();
 
+                   /// \brief Writes _count characters to the string buffer
+                   /// \param[in] _char Input rharacter array.
+                   /// \param[in] _count Number of characters in array.
+                   /// \return The number of characters successfully written.
+                   public: virtual std::streamsize xsputn(
+                        const char *_char, std::streamsize _count) override;
+
                    /// \brief Sync the stream (output the string buffer
                    /// contents).
                    /// \return Return 0 on success.
@@ -198,6 +205,10 @@ namespace ignition
 
                    /// \brief Level of verbosity
                    public: int verbosity;
+
+                   /// \brief Mutex to syncronize writes to the string buffer
+                   /// and the output stream.
+                   public: std::mutex syncMutex;
                  };
 
       IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
@@ -267,6 +278,7 @@ namespace ignition
       /// \brief A custom prefix. See SetPrefix().
       private: static std::string customPrefix;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+
     };
   }
 }

--- a/include/ignition/common/Console.hh
+++ b/include/ignition/common/Console.hh
@@ -278,7 +278,6 @@ namespace ignition
       /// \brief A custom prefix. See SetPrefix().
       private: static std::string customPrefix;
       IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
-
     };
   }
 }

--- a/include/ignition/common/Console.hh
+++ b/include/ignition/common/Console.hh
@@ -187,13 +187,13 @@ namespace ignition
                    /// \param[in] _char Input rharacter array.
                    /// \param[in] _count Number of characters in array.
                    /// \return The number of characters successfully written.
-                   public: virtual std::streamsize xsputn(
+                   public: std::streamsize xsputn(
                         const char *_char, std::streamsize _count) override;
 
                    /// \brief Sync the stream (output the string buffer
                    /// contents).
                    /// \return Return 0 on success.
-                   public: virtual int sync();
+                   public: int sync() override;
 
                    /// \brief Destination type for the messages.
                    public: LogType type;

--- a/test/performance/logging.cc
+++ b/test/performance/logging.cc
@@ -27,142 +27,179 @@ const uint64_t g_iterations{1000000};
 
 std::atomic<size_t> g_counter = {0};
 
-void WriteToFile(std::string result_filename, std::string content) {
-
-   std::ofstream out;
-   std::ios_base::openmode mode = std::ios_base::out | std::ios_base::app;
-   ;
-   out.open(result_filename.c_str(), mode);
-   if (!out.is_open()) {
-      std::cerr << "Error writing to " << result_filename << std::endl;
-   }
-   out << content << std::flush;
-   std::cout << content;
+void WriteToFile(std::string result_filename, std::string content)
+{
+  std::ofstream out;
+  std::ios_base::openmode mode = std::ios_base::out | std::ios_base::app;
+  out.open(result_filename.c_str(), mode);
+  if (!out.is_open())
+  {
+    std::cerr << "Error writing to " << result_filename << std::endl;
+  }
+  out << content << std::flush;
+  std::cout << content;
 }
 
-void MeasurePeakDuringLogWrites(const size_t id, std::vector<uint64_t>& result) {
-   while (true) {
-      const size_t value_now = ++g_counter;
-      if (value_now > g_iterations) {
-         return;
-      }
-      std::stringstream ss;
-      ss << "Some text to log for thread: " << id << "\n";
-      auto start_time = std::chrono::high_resolution_clock::now();
-      ignmsg << ss.str();
-      auto stop_time = std::chrono::high_resolution_clock::now();
-      uint64_t time_us = std::chrono::duration_cast<std::chrono::microseconds>(stop_time - start_time).count();
-      result.push_back(time_us);
-   }
+void MeasurePeakDuringLogWrites(const size_t id, std::vector<uint64_t> &result)
+{
+  while (true)
+  {
+    const size_t value_now = ++g_counter;
+    if (value_now > g_iterations)
+    {
+      return;
+    }
+    std::stringstream ss;
+    ss << "Some text to log for thread: " << id << "\n";
+    auto start_time = std::chrono::high_resolution_clock::now();
+    ignmsg << ss.str();
+    auto stop_time = std::chrono::high_resolution_clock::now();
+    uint64_t time_us = std::chrono::duration_cast<std::chrono::microseconds>(
+                           stop_time - start_time)
+                           .count();
+    result.push_back(time_us);
+  }
 }
 
-void PrintStats(const std::string& filename,   const std::map<size_t, std::vector<uint64_t>>& threads_result, const uint64_t total_time_in_us) {
-   size_t idx = 0;
-   std::ostringstream oss;
-      for (auto t_result : threads_result) {
-      uint64_t worstUs = (*std::max_element(t_result.second.begin(), t_result.second.end()));
-     oss << idx++ << " the worst thread latency was:" <<  worstUs / uint64_t(1000) << " ms  (" << worstUs << " us)] " << std::endl;
-   }
+void PrintStats(const std::string &filename,
+                const std::map<size_t, std::vector<uint64_t>> &threads_result,
+                const uint64_t total_time_in_us)
+{
+  size_t idx = 0;
+  std::ostringstream oss;
+  for (auto t_result : threads_result)
+  {
+    uint64_t worstUs =
+        (*std::max_element(t_result.second.begin(), t_result.second.end()));
+    oss << idx++ << " the worst thread latency was:" << worstUs / uint64_t(1000)
+        << " ms  (" << worstUs << " us)] " << std::endl;
+  }
 
-
-   oss << "Total time :" << total_time_in_us / uint64_t(1000) << " ms (" << total_time_in_us
-       << " us)" << std::endl;
-   oss << "Average time: " << double(total_time_in_us) / double(g_iterations) << " us" << std::endl;
-   WriteToFile(filename, oss.str());
+  oss << "Total time :" << total_time_in_us / uint64_t(1000) << " ms ("
+      << total_time_in_us << " us)" << std::endl;
+  oss << "Average time: " << double(total_time_in_us) / double(g_iterations)
+      << " us" << std::endl;
+  WriteToFile(filename, oss.str());
 }
 
+void SaveResultToBucketFile(
+    std::string result_filename,
+    const std::map<size_t, std::vector<uint64_t>> &threads_result)
+{
+  // now split the result in buckets of 1ms each so that it's obvious how the
+  // peaks go
+  std::vector<uint64_t> all_measurements;
+  all_measurements.reserve(g_iterations);
+  for (auto &t_result : threads_result)
+  {
+    all_measurements.insert(all_measurements.end(), t_result.second.begin(),
+                            t_result.second.end());
+  }
 
-void SaveResultToBucketFile(std::string result_filename, const std::map<size_t, std::vector<uint64_t>>& threads_result) {
-   // now split the result in buckets of 1ms each so that it's obvious how the peaks go
-   std::vector<uint64_t> all_measurements;
-   all_measurements.reserve(g_iterations);
-   for (auto& t_result : threads_result) {
-      all_measurements.insert(all_measurements.end(), t_result.second.begin(), t_result.second.end());
-   }
+  std::map<uint64_t, uint64_t> bucketsWithEmpty;
+  std::map<uint64_t, uint64_t> buckets;
+  // force empty buckets to appear
+  auto maxValueIterator =
+      std::max_element(all_measurements.begin(), all_measurements.end());
+  const auto kMaxValue = *maxValueIterator;
 
-   std::map<uint64_t, uint64_t> bucketsWithEmpty;
-   std::map<uint64_t, uint64_t> buckets;
-   // force empty buckets to appear
-   auto maxValueIterator = std::max_element(all_measurements.begin(), all_measurements.end());
-   const auto kMaxValue = *maxValueIterator;
+  for (uint64_t idx = 0; idx <= kMaxValue; ++idx)
+  {
+    bucketsWithEmpty[idx] = 0;
+  }
 
-   for (uint64_t idx = 0; idx <= kMaxValue; ++idx) {
-      bucketsWithEmpty[idx]=0;
-   }
+  for (auto value : all_measurements)
+  {
+    ++bucketsWithEmpty[value];
+    ++buckets[value];
+  }
 
-   for (auto value : all_measurements) {
-      ++bucketsWithEmpty[value];
-      ++buckets[value];
-   }
+  /*
+  std::cout << "\n\n Microsecond bucket measurement" << std::endl;
+  for (const auto ms_bucket : buckets) {
+     std::cout << ms_bucket.first << "\t, " << ms_bucket.second << std::endl;
+  }
+  std::cout << "\n\n";
+  */
 
-
-   /*
-   std::cout << "\n\n Microsecond bucket measurement" << std::endl;
-   for (const auto ms_bucket : buckets) {
-      std::cout << ms_bucket.first << "\t, " << ms_bucket.second << std::endl;
-   }
-   std::cout << "\n\n";
-   */
-
-   
-   std::ostringstream oss;
-   // Save to xcel and google doc parsable format. with empty buckets
-   oss << "\n\n Microsecond bucket measurement with zero buckets till max" << std::endl;
-   for (const auto ms_bucket : bucketsWithEmpty) {
-     oss << ms_bucket.first << "\t, " << ms_bucket.second << std::endl;
+  std::ostringstream oss;
+  // Save to xcel and google doc parsable format. with empty buckets
+  oss << "\n\n Microsecond bucket measurement with zero buckets till max"
+      << std::endl;
+  for (const auto ms_bucket : bucketsWithEmpty)
+  {
+    oss << ms_bucket.first << "\t, " << ms_bucket.second << std::endl;
   }
   WriteToFile(result_filename, oss.str());
-  std::cout << "Worst Case Latency, max value: " <<  kMaxValue << std::endl;
-  std::cout << "microsecond bucket result is in file: " << result_filename << std::endl;
+  std::cout << "Worst Case Latency, max value: " << kMaxValue << std::endl;
+  std::cout << "microsecond bucket result is in file: " << result_filename
+            << std::endl;
 }
-} // anonymous
+}  // namespace
 
 void run(size_t number_of_threads)
 {
-   g_counter = 0;
-   ignition::common::Console::SetVerbosity(4);
-   std::vector<std::thread> threads(number_of_threads);
-   std::map<size_t, std::vector<uint64_t>> threads_result;
+  g_counter = 0;
+  ignition::common::Console::SetVerbosity(4);
+  std::vector<std::thread> threads(number_of_threads);
+  std::map<size_t, std::vector<uint64_t>> threads_result;
 
-   for (size_t idx = 0; idx < number_of_threads; ++idx) {
-      // reserve to 1 million for all the result
-      // it's a test so  let's not care about the wasted space
-      threads_result[idx].reserve(g_iterations);
-   }
+  for (size_t idx = 0; idx < number_of_threads; ++idx)
+  {
+    // reserve to 1 million for all the result
+    // it's a test so  let's not care about the wasted space
+    threads_result[idx].reserve(g_iterations);
+  }
 
-    //int queue_size = 1048576; // 2 ^ 20
-    //int queue_size = 524288;  // 2 ^ 19
-   //spdlog::set_async_mode(queue_size); // default size is 1048576
-   auto filename_result = std::to_string(number_of_threads) + ".result.csv";
-   std::ostringstream oss;
-   oss << "Using " << number_of_threads;
-   oss << " to log in total " << g_iterations << " log entries to " << filename_result << std::endl;
-   WriteToFile(filename_result, oss.str());
+  // int queue_size = 1048576; // 2 ^ 20
+  // int queue_size = 524288;  // 2 ^ 19
+  // spdlog::set_async_mode(queue_size); // default size is 1048576
+  auto filename_result = std::to_string(number_of_threads) + ".result.csv";
+  std::ostringstream oss;
+  oss << "Using " << number_of_threads;
+  oss << " to log in total " << g_iterations << " log entries to "
+      << filename_result << std::endl;
+  WriteToFile(filename_result, oss.str());
 
-   //auto start_time_application_total = std::chrono::high_resolution_clock::now();
-   for (uint64_t idx = 0; idx < number_of_threads; ++idx) {
-      threads[idx] = std::thread(MeasurePeakDuringLogWrites, idx, std::ref(threads_result[idx]));
-   }
-   for (size_t idx = 0; idx < number_of_threads; ++idx) {
-      threads[idx].join();
-   }
-   auto stop_time_application_total = std::chrono::high_resolution_clock::now();
+  auto start_time_application_total =
+  std::chrono::high_resolution_clock::now();
+  for (uint64_t idx = 0; idx < number_of_threads; ++idx)
+  {
+    threads[idx] = std::thread(MeasurePeakDuringLogWrites, idx,
+                               std::ref(threads_result[idx]));
+  }
+  for (size_t idx = 0; idx < number_of_threads; ++idx)
+  {
+    threads[idx].join();
+  }
+  auto stop_time_application_total = std::chrono::high_resolution_clock::now();
 
-   //uint64_t total_time_in_us = std::chrono::duration_cast<std::chrono::microseconds>(stop_time_application_total - start_time_application_total).count();
+  uint64_t total_time_in_us =
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          stop_time_application_total - start_time_application_total)
+          .count();
 
-//PrintStats(filename_result, threads_result, total_time_in_us);
-   SaveResultToBucketFile(filename_result, threads_result);
-
+  PrintStats(filename_result, threads_result, total_time_in_us);
+  SaveResultToBucketFile(filename_result, threads_result);
 }
 
+class LoggingTest:
+      public ::testing::TestWithParam<std::size_t>
+{
+};
+
+TEST_P(LoggingTest, RunThreads)
+{
+  run(GetParam());
+  SUCCEED();
+}
+
+INSTANTIATE_TEST_SUITE_P(LoggingTest, LoggingTest,
+                         ::testing::Values(1, 2, 4, 8, 16, 32));
+
+/////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
-   run(1);
-   run(2);
-   run(4);
-   run(8);
-   run(16);
-   run(32);
-   return 0;
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
I ran the `PERFORMANCE_logging` test under TSAN and found more data races. One deals with `std::localtime`, which apparently is not thread-safe as it returns a pointer to an internal static object. The others deal with the fact that the `Buffer` class has a `std::string` member inherited from `std::stringbuf` and it (the string) also needs synchronization.

I put the mutex as a member in `Buffer` since it's needed in two functions. This means that each console stream (i.e. ignmsg, ignwarn, etc) gets its own mutex. It turns out we don't really need to synchronize on the `stdout` or `stderr` 
According to https://timsong-cpp.github.io/cppwp/n3337/iostream.objects#overview-4, accessing `stdout` or `stderr` from multiple threads should not cause a data race, so we don't need a global mutex for them. It does say we should synchronize if we want to avoid interleaved messages, but since we write the `prefixString` and the main message separately, we wouldn't be able to avoid interleaved messages even with global synchronization.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
