### PR TITLE
Require ignition-utils1 in find_package call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-utils
-ign_find_package(ignition-utils1 REQUIRED_BY graphics VERSION 1.0)
+ign_find_package(ignition-utils1 REQUIRED VERSION 1.0)
 set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
 
 #--------------------------------------

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,14 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Common 4.2 to 4.3
+
+### Modifications
+
+1. Depends on **ignition-utils1**
+    + Ignition-common now depends on ignition-utils1 in the core library,
+      which provides support for the ImplPtr class.
+
 ## Ignition Common 3.X to 4.X
 
 ### Modifications


### PR DESCRIPTION
# 🦟 Bug fix

Fixes dependency change introduced by #244.

## Summary

Since #244, we are now using ignition-utils1 in the core library, so we need to declare it a required dependency in its find_package call. Currently downstream builds are giving configuration warnings if ign-utils1 is not found but failing to compile. This should cause a configuration failure if ignition-utils1 is not found, instead of a warning.

[![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign_fuel-tools-ci-win&build=8)](https://build.osrfoundation.org/job/ign_fuel-tools-ci-win/8/) https://build.osrfoundation.org/job/ign_fuel-tools-ci-win/8/

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
