### PR TITLE
Remove ign-utils from TempDirectory

### DIFF
--- a/include/ignition/common/TempDirectory.hh
+++ b/include/ignition/common/TempDirectory.hh
@@ -23,7 +23,6 @@
 
 #include <ignition/common/Export.hh>
 #include <ignition/common/Filesystem.hh>
-#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
@@ -101,8 +100,10 @@ namespace ignition
       /// \return the temporary directory path
       public: std::string Path() const;
 
-      /// \brief Private data pointer.
-      IGN_UTILS_IMPL_PTR(dataPtr)
+      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
+      /// \brief Private data pointer
+      private: std::unique_ptr<TempDirectoryPrivate> dataPtr;
+      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
     };
   }  // namespace common
 }  // namespace ignition

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,9 +17,6 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
 target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PRIVATE
   ${ignition-math${IGN_MATH_VER}_INCLUDE_DIRS})
 
-target_include_directories(${PROJECT_LIBRARY_TARGET_NAME} PUBLIC
-  ${ignition-utils${IGN_UTILS_VER}_INCLUDE_DIRS})
-
 # Handle non-Windows configuration settings
 if(NOT WIN32)
   # Link the libraries that we don't expect to find on Windows

--- a/src/TempDirectory.cc
+++ b/src/TempDirectory.cc
@@ -155,7 +155,7 @@ std::string ignition::common::createTempDirectory(
 }
 
 
-class ignition::common::TempDirectory::Implementation
+class ignition::common::TempDirectoryPrivate
 {
   /// \brief Current working directory before creation of temporary dir.
   public: std::string oldPath {""};
@@ -175,7 +175,7 @@ class ignition::common::TempDirectory::Implementation
 TempDirectory::TempDirectory(const std::string &_prefix,
                              const std::string &_subDir,
                              bool _cleanup):
-  dataPtr(ignition::utils::MakeImpl<Implementation>())
+  dataPtr(std::make_unique<TempDirectoryPrivate>())
 {
 
   this->dataPtr->oldPath = common::cwd();


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/ignition-tooling/gazebodistro/pull/45

## Summary

TempDirectory incorrectly added the ign-utils1 dependency, this roills that back.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**