### PR TITLE
Use direct evaluation for SKIP_av.

### DIFF
--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -6,7 +6,7 @@ ign_get_sources(tests)
 # FIXME the mesh test does not work
 list(REMOVE_ITEM tests mesh.cc)
 
-if (${SKIP_av})
+if (SKIP_av)
   list(REMOVE_ITEM tests encoder_timing.cc)
   list(REMOVE_ITEM tests video_encoder.cc)
 endif()


### PR DESCRIPTION
`${}` gives the result in string so something like `colcon build --merge-install --packages-up-to ignition-common4 --cmake-args '-DSKIP_av=true'` might not work as expected.