### PR TITLE
Add support for animation tension

### DIFF
--- a/graphics/include/ignition/common/Animation.hh
+++ b/graphics/include/ignition/common/Animation.hh
@@ -117,6 +117,19 @@ namespace ignition
       public: PoseAnimation(const std::string &_name,
                   const double _length, const bool _loop);
 
+      /// \brief Constructor
+      /// \param[in] _name String name of the animation. This should be unique.
+      /// \param[in] _length Length of the animation in seconds
+      /// \param[in] _loop True == loop the animation
+      /// \param[in] _tension The tension of the trajectory spline. The
+      /// default value of zero equates to a Catmull-Rom spline, which may
+      /// also cause the animation to overshoot keyframes. A value of one will
+      /// cause the animation to stick to the keyframes. This value should
+      /// be in the range 0..1.
+      public: PoseAnimation(const std::string &_name,
+                  const double _length, const bool _loop,
+                  double _tension);
+
       /// \brief Create a pose keyframe at the given time
       /// \param[in] _time Time at which to create the keyframe
       /// \return Pointer to the new keyframe
@@ -233,6 +246,18 @@ namespace ignition
       public: void SetWaypoints(
           std::map<std::chrono::steady_clock::time_point, math::Pose3d>
            _waypoints);
+
+      /// \brief Load all waypoints in the trajectory
+      /// \param[in] _waypoints Map of waypoints, where the key is the absolute
+      /// time of the waypoint and the value is the pose.
+      /// \param[in] _tension The tension of the trajectory spline. The
+      /// default value of zero equates to a Catmull-Rom spline, which may
+      /// also cause the animation to overshoot keyframes. A value of one will
+      /// cause the animation to stick to the keyframes. This value should
+      /// be in the range 0..1.
+      public: void SetWaypoints(
+          std::map<std::chrono::steady_clock::time_point, math::Pose3d>
+           _waypoints, double _tension);
 
       /// \brief Private data pointer.
       IGN_UTILS_IMPL_PTR(dataPtr)


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature


## Summary

PoseAnimation was missing the tension parameter, which was implemented in [gazebo classic](https://github.com/osrf/gazebo/blob/gazebo11/gazebo/common/Animation.hh#L127).

## Test it

I'll update this with a link to the corresponding ign-gazebo PR.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**