### PR TITLE
Fixed macos symbol in common::profiler

### DIFF
--- a/profiler/src/CMakeLists.txt
+++ b/profiler/src/CMakeLists.txt
@@ -58,6 +58,7 @@ ign_add_component(profiler SOURCES ${PROFILER_SRCS} GET_TARGET_NAME profiler_tar
 # Always enable profiler so that it's built, but make it
 # private so that downstream users can still disable profiling
 target_compile_definitions(${profiler_target} PRIVATE "IGN_PROFILER_ENABLE=1")
+target_compile_definitions(${profiler_target} PRIVATE "RMT_USE_METAL=${RMT_USE_METAL}")
 
 if(IGN_PROFILER_REMOTERY)
   target_compile_definitions(${profiler_target} PRIVATE "IGN_PROFILER_REMOTERY=1")


### PR DESCRIPTION
Signed-off-by: Alejandro Hernández <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

While I was testing the ign-gazebo python interface on macos I noticed that some symbols are missing. This should fix it.

There are some other which are not included, for example: `RMT_USE_D3D11` or `RMT_USE_OPENGL`. Should we need to remove these ones or add the `target_compile_definitions`?

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
