### PR TITLE
Support 16 bit heightmaps

### DIFF
--- a/graphics/include/ignition/common/ImageHeightmap.hh
+++ b/graphics/include/ignition/common/ImageHeightmap.hh
@@ -17,6 +17,7 @@
 #ifndef IGNITION_COMMON_IMAGEHEIGHTMAPDATA_HH_
 #define IGNITION_COMMON_IMAGEHEIGHTMAPDATA_HH_
 
+#include <limits>
 #include <string>
 #include <vector>
 #include <ignition/math/Vector3.hh>

--- a/graphics/include/ignition/common/ImageHeightmap.hh
+++ b/graphics/include/ignition/common/ImageHeightmap.hh
@@ -63,6 +63,66 @@ namespace ignition
 
       /// \brief Image containing the heightmap data.
       private: ignition::common::Image img;
+
+      /// \brief Get Heightmap heights given the image
+      private: template <typename T>
+      void getHeights(T data, const double& maxPixelValue,
+        const int& imgHeight, const int& imgWidth,
+        const unsigned int& pitch, const unsigned int& bpp,
+        const int& _subSampling, unsigned int& _vertSize,
+        const ignition::math::Vector3d &_size,
+        const ignition::math::Vector3d &_scale, 
+        const bool& _flipY, std::vector<float> &_heights)
+      {
+        // Iterate over all the vertices
+        for (unsigned int y = 0; y < _vertSize; ++y)
+        {
+          // yf ranges between 0 and 4
+          double yf = y / static_cast<double>(_subSampling);
+          int y1 = static_cast<int>(std::floor(yf));
+          int y2 = static_cast<int>(std::ceil(yf));
+          if (y2 >= imgHeight)
+            y2 = imgHeight-1;
+          double dy = yf - y1;
+
+          for (unsigned int x = 0; x < _vertSize; ++x)
+          {
+            double xf = x / static_cast<double>(_subSampling);
+            int x1 = static_cast<int>(std::floor(xf));
+            int x2 = static_cast<int>(std::ceil(xf));
+            if (x2 >= imgWidth)
+              x2 = imgWidth-1;
+            double dx = xf - x1;
+
+            double px1 = static_cast<int>(
+              data[y1 * pitch / bpp + x1]) / maxPixelValue;
+            double px2 = static_cast<int>(
+              data[y1 * pitch / bpp + x2]) / maxPixelValue;
+            float h1 = (px1 - ((px1 - px2) * dx));
+
+            double px3 = static_cast<int>(
+              data[y2 * pitch / bpp + x1]) / maxPixelValue;
+            double px4 = static_cast<int>(
+              data[y2 * pitch / bpp + x2]) / maxPixelValue;
+            float h2 = (px3 - ((px3 - px4) * dx));
+
+            float h = (h1 - ((h1 - h2) * dy)) * _scale.Z();
+
+            // invert pixel definition so 1=ground, 0=full height,
+            //   if the terrain size has a negative z component
+            //   this is mainly for backward compatibility
+            if (_size.Z() < 0)
+              h = 1.0 - h;
+
+            // Store the height for future use
+            if (!_flipY)
+              _heights[y * _vertSize + x] = h;
+            else
+              _heights[(_vertSize - y - 1) * _vertSize + x] = h;
+          }
+        }
+        delete [] data;
+      }
     };
   }
 }

--- a/graphics/include/ignition/common/ImageHeightmap.hh
+++ b/graphics/include/ignition/common/ImageHeightmap.hh
@@ -71,7 +71,7 @@ namespace ignition
         const unsigned int& pitch, const unsigned int& bpp,
         const int& _subSampling, unsigned int& _vertSize,
         const ignition::math::Vector3d &_size,
-        const ignition::math::Vector3d &_scale, 
+        const ignition::math::Vector3d &_scale,
         const bool& _flipY, std::vector<float> &_heights)
       {
         // Iterate over all the vertices

--- a/graphics/include/ignition/common/ImageHeightmap.hh
+++ b/graphics/include/ignition/common/ImageHeightmap.hh
@@ -65,15 +65,32 @@ namespace ignition
       private: ignition::common::Image img;
 
       /// \brief Get Heightmap heights given the image
+      /// \param[in] _data Image data
+      /// \param[in] _pitch Size of a row of image pixels in bytes
+      /// \param[in] _subSampling Subsampling factor
+      /// \param[in] _vertSize Number of points per row.
+      /// \param[in] _size Real dimmensions of the terrain.
+      /// \param[in] _scale Vector3 used to scale the height.
+      /// \param[in] _flipY If true, it inverts the order in which the vector
+      /// is filled.
+      /// \param[out] _heights Vector containing the terrain heights.
       private: template <typename T>
-      void getHeights(T data, const double& maxPixelValue,
-        const int& imgHeight, const int& imgWidth,
-        const unsigned int& pitch, const unsigned int& bpp,
-        const int& _subSampling, unsigned int& _vertSize,
+      void FillHeights(T *_data, int _imgHeight, int _imgWidth,
+        unsigned int _pitch, int _subSampling, unsigned int _vertSize,
         const ignition::math::Vector3d &_size,
         const ignition::math::Vector3d &_scale,
-        const bool& _flipY, std::vector<float> &_heights)
+        bool _flipY, std::vector<float> &_heights)
       {
+        // bytes per pixel
+        unsigned int bpp = _pitch / _imgWidth;
+        // number of channels in a pixel
+        unsigned int channels = bpp / sizeof(T);
+        // number of pixels in a row of image
+        unsigned int pitchInPixels = _pitch / bpp;
+
+        double maxPixelValue =
+            static_cast<double>(std::numeric_limits<T>::max());
+
         // Iterate over all the vertices
         for (unsigned int y = 0; y < _vertSize; ++y)
         {
@@ -81,8 +98,8 @@ namespace ignition
           double yf = y / static_cast<double>(_subSampling);
           int y1 = static_cast<int>(std::floor(yf));
           int y2 = static_cast<int>(std::ceil(yf));
-          if (y2 >= imgHeight)
-            y2 = imgHeight-1;
+          if (y2 >= _imgHeight)
+            y2 = _imgHeight-1;
           double dy = yf - y1;
 
           for (unsigned int x = 0; x < _vertSize; ++x)
@@ -90,22 +107,21 @@ namespace ignition
             double xf = x / static_cast<double>(_subSampling);
             int x1 = static_cast<int>(std::floor(xf));
             int x2 = static_cast<int>(std::ceil(xf));
-            if (x2 >= imgWidth)
-              x2 = imgWidth-1;
+            if (x2 >= _imgWidth)
+              x2 = _imgWidth-1;
             double dx = xf - x1;
 
             double px1 = static_cast<int>(
-              data[y1 * pitch / bpp + x1]) / maxPixelValue;
+              _data[(y1 * pitchInPixels + x1) * channels]) / maxPixelValue;
             double px2 = static_cast<int>(
-              data[y1 * pitch / bpp + x2]) / maxPixelValue;
+              _data[(y1 * pitchInPixels + x2) * channels]) / maxPixelValue;
             float h1 = (px1 - ((px1 - px2) * dx));
 
             double px3 = static_cast<int>(
-              data[y2 * pitch / bpp + x1]) / maxPixelValue;
+              _data[(y2 * pitchInPixels + x1) * channels]) / maxPixelValue;
             double px4 = static_cast<int>(
-              data[y2 * pitch / bpp + x2]) / maxPixelValue;
+              _data[(y2 * pitchInPixels + x2) * channels]) / maxPixelValue;
             float h2 = (px3 - ((px3 - px4) * dx));
-
             float h = (h1 - ((h1 - h2) * dy)) * _scale.Z();
 
             // invert pixel definition so 1=ground, 0=full height,
@@ -121,7 +137,6 @@ namespace ignition
               _heights[(_vertSize - y - 1) * _vertSize + x] = h;
           }
         }
-        delete [] data;
       }
     };
   }

--- a/graphics/include/ignition/common/ImageHeightmap.hh
+++ b/graphics/include/ignition/common/ImageHeightmap.hh
@@ -83,46 +83,46 @@ namespace ignition
         bool _flipY, std::vector<float> &_heights)
       {
         // bytes per pixel
-        unsigned int bpp = _pitch / _imgWidth;
+        const unsigned int bpp = _pitch / _imgWidth;
         // number of channels in a pixel
-        unsigned int channels = bpp / sizeof(T);
+        const unsigned int channels = bpp / sizeof(T);
         // number of pixels in a row of image
-        unsigned int pitchInPixels = _pitch / bpp;
+        const unsigned int pitchInPixels = _pitch / bpp;
 
-        double maxPixelValue =
+        const double maxPixelValue =
             static_cast<double>(std::numeric_limits<T>::max());
 
         // Iterate over all the vertices
         for (unsigned int y = 0; y < _vertSize; ++y)
         {
           // yf ranges between 0 and 4
-          double yf = y / static_cast<double>(_subSampling);
-          int y1 = static_cast<int>(std::floor(yf));
+          const double yf = y / static_cast<double>(_subSampling);
+          const int y1 = static_cast<int>(std::floor(yf));
           int y2 = static_cast<int>(std::ceil(yf));
           if (y2 >= _imgHeight)
-            y2 = _imgHeight-1;
-          double dy = yf - y1;
+            y2 = _imgHeight - 1;
+          const double dy = yf - y1;
 
           for (unsigned int x = 0; x < _vertSize; ++x)
           {
-            double xf = x / static_cast<double>(_subSampling);
-            int x1 = static_cast<int>(std::floor(xf));
+            const double xf = x / static_cast<double>(_subSampling);
+            const int x1 = static_cast<int>(std::floor(xf));
             int x2 = static_cast<int>(std::ceil(xf));
             if (x2 >= _imgWidth)
-              x2 = _imgWidth-1;
-            double dx = xf - x1;
+              x2 = _imgWidth - 1;
+            const double dx = xf - x1;
 
-            double px1 = static_cast<int>(
+            const double px1 = static_cast<int>(
               _data[(y1 * pitchInPixels + x1) * channels]) / maxPixelValue;
-            double px2 = static_cast<int>(
+            const double px2 = static_cast<int>(
               _data[(y1 * pitchInPixels + x2) * channels]) / maxPixelValue;
-            float h1 = (px1 - ((px1 - px2) * dx));
+            const float h1 = (px1 - ((px1 - px2) * dx));
 
-            double px3 = static_cast<int>(
+            const double px3 = static_cast<int>(
               _data[(y2 * pitchInPixels + x1) * channels]) / maxPixelValue;
-            double px4 = static_cast<int>(
+            const double px4 = static_cast<int>(
               _data[(y2 * pitchInPixels + x2) * channels]) / maxPixelValue;
-            float h2 = (px3 - ((px3 - px4) * dx));
+            const float h2 = (px3 - ((px3 - px4) * dx));
             float h = (h1 - ((h1 - h2) * dy)) * _scale.Z();
 
             // invert pixel definition so 1=ground, 0=full height,

--- a/graphics/src/ImageHeightmap.cc
+++ b/graphics/src/ImageHeightmap.cc
@@ -60,7 +60,6 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   // Get the image format so we can arrange our heightmap
   // Currently supported: 8-bit and 16-bit.
   auto imgFormat = this->img.PixelFormat();
-  ignmsg << "Heightmap format:" << imgFormat << std::endl; 
 
   unsigned char *data = nullptr;
   unsigned int count;
@@ -77,7 +76,8 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
     imgFormat == ignition::common::Image::PixelFormatType::BGR_INT8 ||
     imgFormat == ignition::common::Image::PixelFormatType::BGRA_INT8)
   {
-    getHeights(data, 255.0, imgHeight, imgWidth, pitch, bpp, _subSampling, _vertSize, _size, _scale, _flipY, _heights);
+    getHeights(data, 255.0, imgHeight, imgWidth, pitch, bpp,
+    _subSampling, _vertSize, _size, _scale, _flipY, _heights);
   }
   else if(imgFormat == ignition::common::Image::PixelFormatType::BGR_INT16 ||
     imgFormat == ignition::common::Image::PixelFormatType::L_INT16 ||
@@ -86,11 +86,13 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
     imgFormat == ignition::common::Image::PixelFormatType::R_FLOAT16)
   {
     uint16_t *dataShort = reinterpret_cast<uint16_t *>(data);
-    getHeights(dataShort, 65535.0,  imgHeight, imgWidth, pitch, bpp, _subSampling, _vertSize, _size, _scale, _flipY, _heights);
+    getHeights(dataShort, 65535.0,  imgHeight, imgWidth, pitch, bpp,
+    _subSampling, _vertSize, _size, _scale, _flipY, _heights);
   }
   else
   {
-    ignerr << "Unsupported image format, heightmaps are only supported for 8-bit and 16-bit grayscale images, heightmap will not be loaded" << std::endl;
+    ignerr << "Unsupported image format, "
+    "heightmap will not be loaded" << std::endl;
     return;
   }
 

--- a/graphics/src/ImageHeightmap.cc
+++ b/graphics/src/ImageHeightmap.cc
@@ -54,9 +54,6 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   // Bytes per row
   unsigned int pitch = this->img.Pitch();
 
-  // Bytes per pixel
-  unsigned int bpp = pitch / imgWidth;
-
   // Get the image format so we can arrange our heightmap
   // Currently supported: 8-bit and 16-bit.
   auto imgFormat = this->img.PixelFormat();
@@ -65,7 +62,7 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   unsigned int count;
   this->img.Data(&data, count);
 
-  if(imgFormat == ignition::common::Image::PixelFormatType::L_INT8 ||
+  if (imgFormat == ignition::common::Image::PixelFormatType::L_INT8 ||
     imgFormat == ignition::common::Image::PixelFormatType::RGB_INT8 ||
     imgFormat == ignition::common::Image::PixelFormatType::RGBA_INT8 ||
     imgFormat == ignition::common::Image::PixelFormatType::BAYER_BGGR8 ||
@@ -76,26 +73,26 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
     imgFormat == ignition::common::Image::PixelFormatType::BGR_INT8 ||
     imgFormat == ignition::common::Image::PixelFormatType::BGRA_INT8)
   {
-    getHeights(data, 255.0, imgHeight, imgWidth, pitch, bpp,
-    _subSampling, _vertSize, _size, _scale, _flipY, _heights);
+    this->FillHeights<unsigned char>(data, imgHeight, imgWidth, pitch,
+        _subSampling, _vertSize, _size, _scale, _flipY, _heights);
   }
-  else if(imgFormat == ignition::common::Image::PixelFormatType::BGR_INT16 ||
+  else if (imgFormat == ignition::common::Image::PixelFormatType::BGR_INT16 ||
     imgFormat == ignition::common::Image::PixelFormatType::L_INT16 ||
     imgFormat == ignition::common::Image::PixelFormatType::RGB_FLOAT16 ||
     imgFormat == ignition::common::Image::PixelFormatType::RGB_INT16 ||
     imgFormat == ignition::common::Image::PixelFormatType::R_FLOAT16)
   {
     uint16_t *dataShort = reinterpret_cast<uint16_t *>(data);
-    getHeights(dataShort, 65535.0,  imgHeight, imgWidth, pitch, bpp,
-    _subSampling, _vertSize, _size, _scale, _flipY, _heights);
+    this->FillHeights<uint16_t>(dataShort, imgHeight, imgWidth, pitch,
+        _subSampling, _vertSize, _size, _scale, _flipY, _heights);
   }
   else
   {
     ignerr << "Unsupported image format, "
-    "heightmap will not be loaded" << std::endl;
+      "heightmap will not be loaded" << std::endl;
     return;
   }
-
+  delete [] data;
 }
 
 //////////////////////////////////////////////////

--- a/graphics/src/ImageHeightmap.cc
+++ b/graphics/src/ImageHeightmap.cc
@@ -61,6 +61,45 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   unsigned int count;
   this->img.Data(&data, count);
 
+  // Get the image format so we can arrange our heightmap
+  // Currently supported: 8-bit, 16-bit and 32-bit.
+  auto imgFormat = this->img.PixelFormat();
+
+  double maxPixelValue;
+  if(imgFormat == ignition::common::Image::PixelFormatType::L_INT8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGB_INT8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGBA_INT8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BAYER_BGGR8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GBRG8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GRBG8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GRBG8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BAYER_RGGB8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BGR_INT8 ||
+    imgFormat == ignition::common::Image::PixelFormatType::BGRA_INT8)
+  {
+    maxPixelValue = 255.0;
+  }
+  else if(imgFormat == ignition::common::Image::PixelFormatType::BGR_INT16 ||
+    imgFormat == ignition::common::Image::PixelFormatType::L_INT16 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGB_FLOAT16 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGB_INT16 ||
+    imgFormat == ignition::common::Image::PixelFormatType::R_FLOAT16)
+  {
+    maxPixelValue = 65535.0;
+  }
+  else if(imgFormat == ignition::common::Image::PixelFormatType::BGR_INT32 ||
+    imgFormat == ignition::common::Image::PixelFormatType::R_FLOAT32 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGB_FLOAT32 ||
+    imgFormat == ignition::common::Image::PixelFormatType::RGB_INT32)
+  {
+    maxPixelValue = 4294967295.0;
+  }
+  else
+  {
+    ignerr << "Unknown image format, heightmap will not be loaded" << std::endl;
+    return;
+  }
+
   // Iterate over all the vertices
   for (unsigned int y = 0; y < _vertSize; ++y)
   {
@@ -81,12 +120,16 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
         x2 = imgWidth-1;
       double dx = xf - x1;
 
-      double px1 = static_cast<int>(data[y1 * pitch + x1 * bpp]) / 255.0;
-      double px2 = static_cast<int>(data[y1 * pitch + x2 * bpp]) / 255.0;
+      double px1 = static_cast<int>(
+        data[y1 * pitch + x1 * bpp]) / maxPixelValue;
+      double px2 = static_cast<int>(
+        data[y1 * pitch + x2 * bpp]) / maxPixelValue;
       float h1 = (px1 - ((px1 - px2) * dx));
 
-      double px3 = static_cast<int>(data[y2 * pitch + x1 * bpp]) / 255.0;
-      double px4 = static_cast<int>(data[y2 * pitch + x2 * bpp]) / 255.0;
+      double px3 = static_cast<int>(
+        data[y2 * pitch + x1 * bpp]) / maxPixelValue;
+      double px4 = static_cast<int>(
+        data[y2 * pitch + x2 * bpp]) / maxPixelValue;
       float h2 = (px3 - ((px3 - px4) * dx));
 
       float h = (h1 - ((h1 - h2) * dy)) * _scale.Z();

--- a/graphics/src/ImageHeightmap.cc
+++ b/graphics/src/ImageHeightmap.cc
@@ -66,16 +66,7 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   auto imgFormat = this->img.PixelFormat();
 
   double maxPixelValue;
-  if(imgFormat == ignition::common::Image::PixelFormatType::L_INT8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::RGB_INT8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::RGBA_INT8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BAYER_BGGR8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GBRG8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GRBG8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BAYER_GRBG8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BAYER_RGGB8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BGR_INT8 ||
-    imgFormat == ignition::common::Image::PixelFormatType::BGRA_INT8)
+  if(imgFormat == ignition::common::Image::PixelFormatType::L_INT8)
   {
     maxPixelValue = 255.0;
     // Iterate over all the vertices
@@ -127,11 +118,7 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
     }
     delete [] data;
   }
-  else if(imgFormat == ignition::common::Image::PixelFormatType::BGR_INT16 ||
-    imgFormat == ignition::common::Image::PixelFormatType::L_INT16 ||
-    imgFormat == ignition::common::Image::PixelFormatType::RGB_FLOAT16 ||
-    imgFormat == ignition::common::Image::PixelFormatType::RGB_INT16 ||
-    imgFormat == ignition::common::Image::PixelFormatType::R_FLOAT16)
+  else if(imgFormat == ignition::common::Image::PixelFormatType::L_INT16)
   {
     maxPixelValue = 65535.0;
     uint16_t *dataShort = reinterpret_cast<uint16_t *>(data);
@@ -186,7 +173,7 @@ void ImageHeightmap::FillHeightMap(int _subSampling,
   }
   else
   {
-    ignerr << "Unknown image format, heightmap will not be loaded" << std::endl;
+    ignerr << "Unsupported image format, heightmaps are only supported for 8-bit and 16-bit grayscale images, heightmap will not be loaded" << std::endl;
     return;
   }
 

--- a/graphics/src/ImageHeightmap_TEST.cc
+++ b/graphics/src/ImageHeightmap_TEST.cc
@@ -94,7 +94,7 @@ TEST_F(ImageHeightmapTest, FillHeightmap)
   // Check the elevation of some control points
   EXPECT_NEAR(0.0, elevations.at(0), ELEVATION_TOL);
   EXPECT_NEAR(10.0, elevations.at(elevations.size() - 1), ELEVATION_TOL);
-  EXPECT_NEAR(5.0, elevations.at((elevations.size() / 2)), ELEVATION_TOL);
+  EXPECT_NEAR(5.0, elevations.at(elevations.size() / 2), ELEVATION_TOL);
 }
 
 /////////////////////////////////////////////////

--- a/graphics/src/ImageHeightmap_TEST.cc
+++ b/graphics/src/ImageHeightmap_TEST.cc
@@ -94,7 +94,7 @@ TEST_F(ImageHeightmapTest, FillHeightmap)
   // Check the elevation of some control points
   EXPECT_NEAR(0.0, elevations.at(0), ELEVATION_TOL);
   EXPECT_NEAR(10.0, elevations.at(elevations.size() - 1), ELEVATION_TOL);
-  EXPECT_NEAR(5.0, elevations.at((elevations.size() / 2) - 2), ELEVATION_TOL);
+  EXPECT_NEAR(5.0, elevations.at((elevations.size() / 2)), ELEVATION_TOL);
 }
 
 /////////////////////////////////////////////////

--- a/graphics/src/ImageHeightmap_TEST.cc
+++ b/graphics/src/ImageHeightmap_TEST.cc
@@ -94,7 +94,7 @@ TEST_F(ImageHeightmapTest, FillHeightmap)
   // Check the elevation of some control points
   EXPECT_NEAR(0.0, elevations.at(0), ELEVATION_TOL);
   EXPECT_NEAR(10.0, elevations.at(elevations.size() - 1), ELEVATION_TOL);
-  EXPECT_NEAR(5.0, elevations.at(elevations.size() / 2), ELEVATION_TOL);
+  EXPECT_NEAR(5.0, elevations.at((elevations.size() / 2) - 2), ELEVATION_TOL);
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #265 

## Summary
Assuming [PixelFormat](https://github.com/ignitionrobotics/ign-common/blob/ign-common4/graphics/src/Image.cc#L516) function returns a correct value this should allow supporting 8, 16 and 32 bit heightmaps. Having said that I tried to test this with a hand constructed 16bit version of city_terrain.jpg (just multiplied each value by 256 didn't want to spend so much time on that), ~the PixelFormat function is still returning `L_INT8` (which is the same as the 8 bit version) causing the spikes. This needs to be resolved as well. I'll try to have a deeper look on why we aren't getting correct return from this function.~ That was my bad that I left the extension of 16 bit image as .jpg (should have been png), it's now throwing a very suppressive error messages starting with `[Err] [Image.cc:478] Image: Coordinates out of range [0 0]` and going through all the pixels.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸

**Note to maintainers**: Remember to use **Squash-Merge**
