### PR TITLE
Normalize normal vectors from OBJ.

### DIFF
--- a/graphics/src/OBJLoader.cc
+++ b/graphics/src/OBJLoader.cc
@@ -234,6 +234,7 @@ Mesh *OBJLoader::Load(const std::string &_filename)
           ignition::math::Vector3d normal(attrib.normals[3 * nIdx],
                                           attrib.normals[3 * nIdx + 1],
                                           attrib.normals[3 * nIdx + 2]);
+          normal.Normalize();
           subMesh->AddNormal(normal);
         }
         // texcoords


### PR DESCRIPTION
Normal vectors that are not normalized might cause incorrect rendering results.