### PR TITLE
Use libexec to install binary remotery_vis

### DIFF
--- a/profiler/src/CMakeLists.txt
+++ b/profiler/src/CMakeLists.txt
@@ -88,7 +88,7 @@ if(TARGET UNIT_Profiler_Remotery_TEST)
 endif()
 
 if(IGN_PROFILER_REMOTERY)
-  set(IGN_PROFILER_SCRIPT_PATH ${CMAKE_INSTALL_LIBDIR}/ignition/ignition-common${PROJECT_VERSION_MAJOR})
+  set(IGN_PROFILER_SCRIPT_PATH ${CMAKE_INSTALL_LIBEXECDIR}/ignition/ignition-common${PROJECT_VERSION_MAJOR})
   set(IGN_PROFILER_VIS_PATH ${IGN_DATA_INSTALL_DIR}/profiler_vis)
 
   configure_file(Remotery/ign_remotery_vis.in


### PR DESCRIPTION

# 🎉 New feature

Closes #271

## Summary
We are installing the profiler visualizer binary under the standard library path which is something that does not fit well according to the [FHR](https://refspecs.linuxfoundation.org/FHS_3.0/fhs-3.0.html#usrlibexec). libexec seems a better place for them.

> 4.7.1. Purpose
> /usr/libexec includes internal binaries that are not intended to be executed directly by users or shell scripts. Applications may use a single subdirectory under /usr/libexec.
