### PR TITLE
Use ImplPtr where relevant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(IGN_MATH_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-utils
-ign_find_package(ignition-utils1 REQUIRED_BY graphics VERSION 1.0)
+ign_find_package(ignition-utils1 REQUIRED VERSION 1.0)
 set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
 
 #--------------------------------------

--- a/include/ignition/common/Battery.hh
+++ b/include/ignition/common/Battery.hh
@@ -22,15 +22,13 @@
 #include <functional>
 #include <memory>
 #include <ignition/common/Export.hh>
-#include <ignition/common/SuppressWarning.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
   namespace common
   {
-    // Forward declare private data class.
-    class BatteryPrivate;
-
     /// \brief A battery abstraction
     ///
     /// The default battery model is ideal: It just takes the initial voltage
@@ -59,13 +57,22 @@ namespace ignition
       /// \param[in] _battery Battery to copy.
       public: Battery(const Battery &_battery);
 
-      /// \brief Assignment operator
+      /// \brief Copy assignment operator
       /// \param[in] _battery The new battery
       /// \return a reference to this instance
       public: Battery &operator=(const Battery &_battery);
 
+      /// \brief Move constructor
+      /// \param[in] _battery Battery to move.
+      public: Battery(Battery &&_battery);
+
+      /// \brief Move assignment operator
+      /// \param[in] _battery The new battery
+      /// \return a reference to this instance
+      public: Battery &operator=(Battery &&_battery);
+
       /// \brief Destructor.
-      public: virtual ~Battery();
+      public: virtual ~Battery() = default;
 
       /// \brief Equal to operator
       /// \param[in] _battery the battery to compare to
@@ -163,11 +170,8 @@ namespace ignition
       /// \return New battery voltage.
       private: double UpdateDefault(Battery *_battery);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
-      /// \brief Private data pointer.
-      private: std::unique_ptr<BatteryPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      /// \brief Pointer to private data.
+      IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
 
     /// \def BatteryPtr

--- a/include/ignition/common/Battery.hh
+++ b/include/ignition/common/Battery.hh
@@ -17,10 +17,11 @@
 #ifndef IGNITION_COMMON_BATTERY_HH_
 #define IGNITION_COMMON_BATTERY_HH_
 
-#include <map>
-#include <string>
 #include <functional>
+#include <map>
 #include <memory>
+#include <string>
+
 #include <ignition/common/Export.hh>
 
 #include <ignition/utils/ImplPtr.hh>

--- a/include/ignition/common/Filesystem.hh
+++ b/include/ignition/common/Filesystem.hh
@@ -18,7 +18,6 @@
 #ifndef IGNITION_COMMON_FILESYSTEM_HH_
 #define IGNITION_COMMON_FILESYSTEM_HH_
 
-#include <memory>
 #include <string>
 
 #include <ignition/common/Export.hh>

--- a/include/ignition/common/Filesystem.hh
+++ b/include/ignition/common/Filesystem.hh
@@ -22,7 +22,8 @@
 #include <string>
 
 #include <ignition/common/Export.hh>
-#include <ignition/common/SuppressWarning.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
@@ -253,19 +254,19 @@ namespace ignition
     std::string IGNITION_COMMON_VISIBLE uniqueDirectoryPath(
         const std::string &_dir);
 
-    /// \internal
-    class DirIterPrivate;
-
     /// \class DirIter Filesystem.hh
     /// \brief A class for iterating over all items in a directory.
     class IGNITION_COMMON_VISIBLE DirIter
     {
+      /// \brief Constructor for end element.
+      public: DirIter();
+
       /// \brief Constructor.
       /// \param[in] _in  Directory to iterate over.
       public: explicit DirIter(const std::string &_in);
 
-      /// \brief Constructor for end element.
-      public: DirIter();
+      /// \brief Destructor
+      public: ~DirIter();
 
       /// \brief Dereference operator; returns current directory record.
       /// \return A string representing the entire path of the directory
@@ -282,9 +283,6 @@ namespace ignition
       /// \return true if the iterators are equal, false otherwise.
       public: bool operator!=(const DirIter &_other) const;
 
-      /// \brief Destructor
-      public: ~DirIter();
-
       /// \brief Move to the next directory record, skipping . and .. records.
       private: void Next();
 
@@ -294,10 +292,8 @@ namespace ignition
       /// \brief Close an open directory handle.
       private: void CloseHandle();
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \brief Private data.
-      private: std::unique_ptr<DirIterPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      /// \brief Pointer to private data.
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
   }
 }

--- a/include/ignition/common/SystemPaths.hh
+++ b/include/ignition/common/SystemPaths.hh
@@ -34,8 +34,9 @@
 #include <vector>
 
 #include <ignition/common/Export.hh>
-#include <ignition/common/SuppressWarning.hh>
 #include <ignition/common/URI.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
@@ -52,9 +53,6 @@ namespace ignition
     {
       /// \brief Constructor for SystemPaths
       public: SystemPaths();
-
-      /// \brief Destructor
-      public: virtual ~SystemPaths();
 
       /// \brief Get the log path. If IGN_LOG_PATH environment variable is set,
       /// then this path is used. If not, the path is $HOME/.ignition, and in
@@ -205,10 +203,8 @@ namespace ignition
       /// uses to separate different paths from each other.
       public: static char Delimiter();
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \brief Private data pointer
-      private: std::unique_ptr<SystemPathsPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      /// \brief Pointer to private data.
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
   }
 }

--- a/include/ignition/common/SystemPaths.hh
+++ b/include/ignition/common/SystemPaths.hh
@@ -29,7 +29,6 @@
 
 #include <functional>
 #include <list>
-#include <memory>
 #include <string>
 #include <vector>
 

--- a/include/ignition/common/TempDirectory.hh
+++ b/include/ignition/common/TempDirectory.hh
@@ -21,15 +21,14 @@
 #include <memory>
 #include <string>
 
-#include <ignition/common/Export.hh>
 #include <ignition/common/Filesystem.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
   namespace common
   {
-    class TempDirectoryPrivate;
-
     /// \brief Return the path to a directory suitable for temporary files.
     ///
     /// Calls std::filesystem::temp_directory_path, refer to the standard
@@ -100,10 +99,8 @@ namespace ignition
       /// \return the temporary directory path
       public: std::string Path() const;
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \brief Private data pointer
-      private: std::unique_ptr<TempDirectoryPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      /// \brief Pointer to private data.
+      IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
   }  // namespace common
 }  // namespace ignition

--- a/include/ignition/common/TempDirectory.hh
+++ b/include/ignition/common/TempDirectory.hh
@@ -18,9 +18,9 @@
 #ifndef IGNITION_COMMON_TEMPDIRECTORY_HH_
 #define IGNITION_COMMON_TEMPDIRECTORY_HH_
 
-#include <memory>
 #include <string>
 
+#include <ignition/common/Export.hh>
 #include <ignition/common/Filesystem.hh>
 
 #include <ignition/utils/ImplPtr.hh>

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -17,7 +17,6 @@
 #ifndef IGNITION_COMMON_URI_HH_
 #define IGNITION_COMMON_URI_HH_
 
-#include <memory>
 #include <optional>
 #include <string>
 

--- a/include/ignition/common/URI.hh
+++ b/include/ignition/common/URI.hh
@@ -22,19 +22,13 @@
 #include <string>
 
 #include <ignition/common/Export.hh>
-#include <ignition/common/SuppressWarning.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
   namespace common
   {
-    // Forward declare private data classes.
-    class URIAuthorityPrivate;
-    class URIPathPrivate;
-    class URIQueryPrivate;
-    class URIFragmentPrivate;
-    class URIPrivate;
-
     /// A URI authority contains userinfo, host, and port data. The format
     /// of a URI authority is `//userinfo@host:port`. The `userinfo` and
     /// `port` components are optional.
@@ -64,16 +58,9 @@ namespace ignition
       /// \brief Constructor
       public: URIAuthority();
 
-      /// \brief Copy constructor.
-      /// \param[in] _path Another URIAuthority.
-      public: URIAuthority(const URIAuthority &_path);
-
       /// \brief Construct a URIAuthority object from a string.
       /// \param[in] _str A string.
       public: explicit URIAuthority(const std::string &_str);
-
-      /// \brief Destructor
-      public: virtual ~URIAuthority();
 
       /// \brief Remove all parts of the authority
       public: void Clear();
@@ -85,7 +72,7 @@ namespace ignition
 
       /// \brief Set the user information.
       /// \param[in] _userInfo The user information string.
-      public: void SetUserInfo(const std::string &_userInfo) const;
+      public: void SetUserInfo(const std::string &_userInfo);
 
       /// \brief Get the host.
       /// \return The host.
@@ -93,7 +80,7 @@ namespace ignition
 
       /// \brief Set the host.
       /// \param[in] _host The host.
-      public: void SetHost(const std::string &_host) const;
+      public: void SetHost(const std::string &_host);
 
       /// \brief True if an empty host is considered valid.
       /// \return True if an empty host is valid.
@@ -103,14 +90,14 @@ namespace ignition
       /// This should only be set to true if the corresponding URIScheme
       /// is "file".
       /// \param[in] _valid True if an empty host is valid.
-      public: void SetEmptyHostValid(bool _valid) const;
+      public: void SetEmptyHostValid(bool _valid);
 
       /// \brief Get the port.
       /// \return The port number, which is optional.
       public: std::optional<int> Port() const;
 
       /// \brief Set the port number.
-      public: void SetPort(int _port) const;
+      public: void SetPort(int _port);
 
       /// \brief Return true if the two authorities match.
       /// \param[in] _auth Authority.
@@ -120,11 +107,6 @@ namespace ignition
       /// \brief Get the complete authoriy as a string.
       /// \return The authority as a string.
       public: std::string Str() const;
-
-      /// \brief Assignment operator.
-      /// \param[in] _auth Another URIAuthority.
-      /// \return Itself.
-      public: URIAuthority &operator=(const URIAuthority &_auth);
 
       /// \brief Return true if the string is a valid path.
       /// \param[in] _str String to check.
@@ -148,11 +130,8 @@ namespace ignition
       public: bool Parse(const std::string &_str,
                   bool _emptyHostValid = false);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
       /// \brief Pointer to private data.
-      private: std::unique_ptr<URIAuthorityPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
 
     /// \brief A URI path contains a sequence of segments separated by `/`.
@@ -169,16 +148,9 @@ namespace ignition
       /// \brief Constructor
       public: URIPath();
 
-      /// \brief Copy constructor.
-      /// \param[in] _path Another URIPath.
-      public: URIPath(const URIPath &_path);
-
       /// \brief Construct a URIPath object from a string.
       /// \param[in] _str A string.
       public: explicit URIPath(const std::string &_str);
-
-      /// \brief Destructor
-      public: virtual ~URIPath();
 
       /// \brief Remove all parts of the path
       public: void Clear();
@@ -249,11 +221,6 @@ namespace ignition
       /// \return The path as a string, with each path part separated by _delim.
       public: std::string Str(const std::string &_delim = "/") const;
 
-      /// \brief Assignment operator.
-      /// \param[in] _path Another URIPath.
-      /// \return Itself.
-      public: URIPath &operator=(const URIPath &_path);
-
       /// \brief Return true if the string is a valid path.
       /// \param[in] _str String to check.
       /// \return True if _str is a valid URI path.
@@ -268,11 +235,8 @@ namespace ignition
       /// \return True if the string could be parsed as a URIPath.
       public: bool Parse(const std::string &_str);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
       /// \brief Pointer to private data.
-      private: std::unique_ptr<URIPathPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
 
     /// \brief The query component of a URI
@@ -285,13 +249,6 @@ namespace ignition
       /// \param[in] _str A string.
       public: explicit URIQuery(const std::string &_str);
 
-      /// \brief Copy constructor
-      /// \param[in] _query Another query component
-      public: URIQuery(const URIQuery &_query);
-
-      /// \brief Destructor
-      public: virtual ~URIQuery();
-
       /// \brief Remove all values of the query
       public: void Clear();
 
@@ -300,11 +257,6 @@ namespace ignition
       /// \param[in] _value Value of the query.
       public: void Insert(const std::string &_key,
                           const std::string &_value);
-
-      /// \brief Assignment operator.
-      /// \param[in] _query another URIQuery.
-      /// \return Itself.
-      public: URIQuery &operator=(const URIQuery &_query);
 
       /// \brief Return true if the two queries contain the same values.
       /// \param[in] _query A URI query to compare.
@@ -331,11 +283,8 @@ namespace ignition
       /// \return True if the string can be parsed as a URIQuery.
       public: bool Parse(const std::string &_string);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
       /// \brief Pointer to private data.
-      private: std::unique_ptr<URIQueryPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
 
     /// \brief The fragment component of a URI
@@ -348,20 +297,8 @@ namespace ignition
       /// \param[in] _str A string.
       public: explicit URIFragment(const std::string &_str);
 
-      /// \brief Copy constructor
-      /// \param[in] _fragment Another fragment component
-      public: URIFragment(const URIFragment &_fragment);
-
-      /// \brief Destructor
-      public: virtual ~URIFragment();
-
       /// \brief Remove all values of the fragment
       public: void Clear();
-
-      /// \brief Assignment operator.
-      /// \param[in] _fragment another URIFragment.
-      /// \return Itself.
-      public: URIFragment &operator=(const URIFragment &_fragment);
 
       /// \brief Assignment operator.
       /// \param[in] _fragment another URIFragment.
@@ -391,11 +328,8 @@ namespace ignition
       /// \return True if the string can be parsed as a URIFragment.
       public: bool Parse(const std::string &_string);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
       /// \brief Pointer to private data.
-      private: std::unique_ptr<URIFragmentPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
 
     /// \brief A complete URI which has the following components:
@@ -414,13 +348,6 @@ namespace ignition
       /// empty.
       public: explicit URI(const std::string &_str,
           bool _hasAuthority = false);
-
-      /// \brief Copy constructor
-      /// \param[in] _uri Another URI.
-      public: URI(const URI &_uri);
-
-      /// \brief Destructor.
-      public: ~URI();
 
       /// \brief Get the URI as a string, which has the form:
       ///
@@ -475,11 +402,6 @@ namespace ignition
       /// \return A const reference of the fragment.
       public: const URIFragment &Fragment() const;
 
-      /// \brief Assignment operator.
-      /// \param[in] _uri Another URI.
-      /// \return Itself.
-      public: URI &operator=(const URI &_uri);
-
       /// \brief Return true if the two URIs match.
       /// \param[in] _uri Another URI to compare.
       /// \return True if the two URIs match.
@@ -503,11 +425,8 @@ namespace ignition
       /// \return True if the string can be parsed as a URI.
       public: bool Parse(const std::string &_str);
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \internal
       /// \brief Pointer to private data.
-      private: std::unique_ptr<URIPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_IMPL_PTR(dataPtr)
     };
   }
 }

--- a/include/ignition/common/WorkerPool.hh
+++ b/include/ignition/common/WorkerPool.hh
@@ -22,7 +22,8 @@
 #include <memory>
 
 #include <ignition/common/Export.hh>
-#include <ignition/common/SuppressWarning.hh>
+
+#include <ignition/utils/ImplPtr.hh>
 
 namespace ignition
 {
@@ -62,10 +63,7 @@ namespace ignition
         const std::chrono::steady_clock::duration &_timeout =
           std::chrono::steady_clock::duration::zero());
 
-      IGN_COMMON_WARN_IGNORE__DLL_INTERFACE_MISSING
-      /// \brief private implementation pointer
-      private: std::unique_ptr<WorkerPoolPrivate> dataPtr;
-      IGN_COMMON_WARN_RESUME__DLL_INTERFACE_MISSING
+      IGN_UTILS_UNIQUE_IMPL_PTR(dataPtr)
     };
   }
 }

--- a/include/ignition/common/WorkerPool.hh
+++ b/include/ignition/common/WorkerPool.hh
@@ -19,7 +19,6 @@
 #define IGNITION_COMMON_WORKER_POOL_HH_
 
 #include <functional>
-#include <memory>
 
 #include <ignition/common/Export.hh>
 

--- a/src/Battery.cc
+++ b/src/Battery.cc
@@ -24,7 +24,7 @@ using namespace ignition;
 using namespace common;
 
 /// \brief Private data for the Battery class
-class ignition::common::BatteryPrivate
+class ignition::common::Battery::Implementation
 {
   /// \brief Initial voltage in volts.
   public: double initVoltage = 0.0;
@@ -51,7 +51,7 @@ class ignition::common::BatteryPrivate
 
 /////////////////////////////////////////////////
 Battery::Battery()
-: dataPtr(new BatteryPrivate)
+  : dataPtr(ignition::utils::MakeUniqueImpl<Implementation>())
 {
   this->SetUpdateFunc(std::bind(&Battery::UpdateDefault, this,
         std::placeholders::_1));
@@ -59,7 +59,7 @@ Battery::Battery()
 
 /////////////////////////////////////////////////
 Battery::Battery(const std::string &_name, const double _voltage)
-: dataPtr(new BatteryPrivate)
+  : Battery()
 {
   this->dataPtr->name = _name;
   this->dataPtr->initVoltage = _voltage;
@@ -67,7 +67,7 @@ Battery::Battery(const std::string &_name, const double _voltage)
 
 /////////////////////////////////////////////////
 Battery::Battery(const Battery &_battery)
-  : dataPtr(new BatteryPrivate)
+  : Battery()
 {
   this->dataPtr->initVoltage = _battery.dataPtr->initVoltage;
   this->dataPtr->realVoltage = _battery.dataPtr->realVoltage;
@@ -84,6 +84,12 @@ Battery::Battery(const Battery &_battery)
 
   this->dataPtr->name = _battery.dataPtr->name;
   // Mutex neither copyable nor movable.
+}
+
+/////////////////////////////////////////////////
+Battery::Battery(Battery &&_battery)
+  : dataPtr(std::exchange(_battery.dataPtr, nullptr))
+{
 }
 
 /////////////////////////////////////////////////
@@ -108,8 +114,10 @@ Battery &Battery::operator=(const Battery &_battery)
 }
 
 /////////////////////////////////////////////////
-Battery::~Battery()
+Battery &Battery::operator=(Battery &&_battery)
 {
+  std::swap(this->dataPtr, _battery.dataPtr);
+  return *this;
 }
 
 /////////////////////////////////////////////////

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,8 +9,13 @@ ign_create_core_library(
   CXX_STANDARD 17)
 
 # Link the libraries that we always need
-target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
-  PRIVATE ${DL_TARGET})
+target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME} 
+  PRIVATE 
+    ${DL_TARGET}
+  PUBLIC
+    ignition-utils${IGN_UTILS_VER}::ignition-utils${IGN_UTILS_VER}
+)
+
 
 # This is required by the WorkerPool::WaitForResults(const Time &_timeout)
 # TODO(anyone): IGN_DEPRECATED(4). Remove this part when the method is removed

--- a/src/FilesystemBoost.cc
+++ b/src/FilesystemBoost.cc
@@ -64,7 +64,7 @@ namespace ignition
   {
     /// \internal
     /// \brief Private data for the DirIter class.
-    class DirIterPrivate
+    class DirIter::Implementation
     {
       /// \def current
       /// \brief The current directory item.
@@ -151,7 +151,8 @@ namespace ignition
     }
 
     //////////////////////////////////////////////////
-    DirIter::DirIter(const std::string &_in) : dataPtr(new DirIterPrivate)
+    DirIter::DirIter(const std::string &_in)
+      : dataPtr(ignition::utils::MakeImpl<Implementation>())
     {
       this->dataPtr->dirname = _in;
 
@@ -429,7 +430,8 @@ namespace ignition
     }
 
     //////////////////////////////////////////////////
-    DirIter::DirIter(const std::string &_in) : dataPtr(new DirIterPrivate)
+    DirIter::DirIter(const std::string &_in)
+      : dataPtr(ignition::utils::MakeImpl<Implementation>())
     {
       // use a form of search Sebastian Martel reports will work with Win98
       this->dataPtr->dirname = _in;
@@ -590,7 +592,7 @@ namespace ignition
     }
 
     //////////////////////////////////////////////////
-    DirIter::DirIter() : dataPtr(new DirIterPrivate)
+    DirIter::DirIter() : dataPtr(ignition::utils::MakeImpl<Implementation>())
     {
       this->dataPtr->current = "";
 

--- a/src/SystemPaths.cc
+++ b/src/SystemPaths.cc
@@ -40,7 +40,7 @@ using namespace ignition;
 using namespace common;
 
 // Private data class
-class ignition::common::SystemPathsPrivate
+class ignition::common::SystemPaths::Implementation
 {
   /// \brief Name of the environment variable to check for plugin paths
   public: std::string pluginPathEnv = "IGN_PLUGIN_PATH";
@@ -85,7 +85,7 @@ void insertUnique(const std::string &_path, std::list<std::string> &_list)
 
 //////////////////////////////////////////////////
 SystemPaths::SystemPaths()
-: dataPtr(new SystemPathsPrivate)
+: dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
   std::string home, path, fullPath;
   if (!env(IGN_HOMEDIR, home))
@@ -118,11 +118,6 @@ SystemPaths::SystemPaths()
   // Populate this->dataPtr->filePaths with values from the default
   // environment variable.
   this->SetFilePathEnv(this->dataPtr->filePathEnv);
-}
-
-/////////////////////////////////////////////////
-SystemPaths::~SystemPaths()
-{
 }
 
 /////////////////////////////////////////////////
@@ -240,7 +235,7 @@ std::string SystemPaths::NormalizeDirectoryPath(const std::string &_path)
 }
 
 /////////////////////////////////////////////////
-std::vector<std::string> SystemPathsPrivate::GenerateLibraryPaths(
+std::vector<std::string> SystemPaths::Implementation::GenerateLibraryPaths(
     const std::string &_libName) const
 {
   std::string lowercaseLibName = lowercase(_libName);

--- a/src/TempDirectory.cc
+++ b/src/TempDirectory.cc
@@ -155,7 +155,7 @@ std::string ignition::common::createTempDirectory(
 }
 
 
-class ignition::common::TempDirectoryPrivate
+class ignition::common::TempDirectory::Implementation
 {
   /// \brief Current working directory before creation of temporary dir.
   public: std::string oldPath {""};
@@ -175,7 +175,7 @@ class ignition::common::TempDirectoryPrivate
 TempDirectory::TempDirectory(const std::string &_prefix,
                              const std::string &_subDir,
                              bool _cleanup):
-  dataPtr(std::make_unique<TempDirectoryPrivate>())
+  dataPtr(ignition::utils::MakeUniqueImpl<Implementation>())
 {
 
   this->dataPtr->oldPath = common::cwd();

--- a/src/URI.cc
+++ b/src/URI.cc
@@ -32,7 +32,7 @@ static const char kSchemeDelim[] = ":";
 static const char kAuthDelim[] = "//";
 
 /// \brief URIAuthority private data.
-class ignition::common::URIAuthorityPrivate
+class ignition::common::URIAuthority::Implementation
 {
   /// \brief The user information.
   public: std::string userInfo;
@@ -52,7 +52,7 @@ class ignition::common::URIAuthorityPrivate
 };
 
 /// \brief URIPath private data.
-class ignition::common::URIPathPrivate
+class ignition::common::URIPath::Implementation
 {
   /// \brief A helper method to determine if the given string represents
   ///        an absolute path starting segment or not.
@@ -73,21 +73,21 @@ class ignition::common::URIPathPrivate
 };
 
 /// \brief URIQuery private data.
-class ignition::common::URIQueryPrivate
+class ignition::common::URIQuery::Implementation
 {
   /// \brief The key/value tuples that compose the query.
   public: std::vector<std::pair<std::string, std::string>> values;
 };
 
 /// \brief URIFragment private data.
-class ignition::common::URIFragmentPrivate
+class ignition::common::URIFragment::Implementation
 {
   /// \brief The value of the fragment.
   public: std::string value;
 };
 
 /// \brief URI private data.
-class ignition::common::URIPrivate
+class ignition::common::URI::Implementation
 {
   /// \brief The URI scheme.
   public: std::string scheme;
@@ -107,15 +107,8 @@ class ignition::common::URIPrivate
 
 //////////////////////////////////////////////////
 URIAuthority::URIAuthority()
-: dataPtr(new URIAuthorityPrivate())
+: dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
-}
-
-//////////////////////////////////////////////////
-URIAuthority::URIAuthority(const URIAuthority &_authority)
-  : URIAuthority()
-{
-  *this = _authority;
 }
 
 //////////////////////////////////////////////////
@@ -127,11 +120,6 @@ URIAuthority::URIAuthority(const std::string &_str)
     ignwarn << "Unable to parse URIAuthority [" << _str << "]. Ignoring."
            << std::endl;
   }
-}
-
-//////////////////////////////////////////////////
-URIAuthority::~URIAuthority()
-{
 }
 
 //////////////////////////////////////////////////
@@ -151,7 +139,7 @@ std::string URIAuthority::UserInfo() const
 }
 
 //////////////////////////////////////////////////
-void URIAuthority::SetUserInfo(const std::string &_userInfo) const
+void URIAuthority::SetUserInfo(const std::string &_userInfo)
 {
   this->dataPtr->userInfo = _userInfo;
 }
@@ -163,7 +151,7 @@ std::string URIAuthority::Host() const
 }
 
 //////////////////////////////////////////////////
-void URIAuthority::SetHost(const std::string &_host) const
+void URIAuthority::SetHost(const std::string &_host)
 {
   this->dataPtr->host = _host;
 }
@@ -175,7 +163,7 @@ std::optional<int> URIAuthority::Port() const
 }
 
 //////////////////////////////////////////////////
-void URIAuthority::SetPort(int _port) const
+void URIAuthority::SetPort(int _port)
 {
   this->dataPtr->port.emplace(_port);
 }
@@ -205,18 +193,6 @@ std::string URIAuthority::Str() const
   }
 
   return "";
-}
-
-//////////////////////////////////////////////////
-URIAuthority &URIAuthority::operator=(const URIAuthority &_auth)
-{
-  this->dataPtr->userInfo = _auth.UserInfo();
-  this->dataPtr->host = _auth.Host();
-  this->dataPtr->port = _auth.Port();
-  this->dataPtr->emptyHostValid = _auth.EmptyHostValid();
-  this->dataPtr->hasEmptyHost = _auth.dataPtr->hasEmptyHost;
-
-  return *this;
 }
 
 //////////////////////////////////////////////////
@@ -319,7 +295,7 @@ bool URIAuthority::EmptyHostValid() const
 }
 
 //////////////////////////////////////////////////
-void URIAuthority::SetEmptyHostValid(bool _valid) const
+void URIAuthority::SetEmptyHostValid(bool _valid)
 {
   this->dataPtr->emptyHostValid = _valid;
 }
@@ -386,12 +362,7 @@ bool URIAuthority::Parse(const std::string &_str, bool _emptyHostValid)
 
 /////////////////////////////////////////////////
 URIPath::URIPath()
-: dataPtr(new URIPathPrivate())
-{
-}
-
-/////////////////////////////////////////////////
-URIPath::~URIPath()
+: dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
 }
 
@@ -404,13 +375,6 @@ URIPath::URIPath(const std::string &_str)
     ignwarn << "Unable to parse URIPath [" << _str << "]. Ignoring."
            << std::endl;
   }
-}
-
-/////////////////////////////////////////////////
-URIPath::URIPath(const URIPath &_path)
-  : URIPath()
-{
-  *this = _path;
 }
 
 /////////////////////////////////////////////////
@@ -583,14 +547,6 @@ std::string URIPath::Str(const std::string &_delim) const
 }
 
 /////////////////////////////////////////////////
-URIPath &URIPath::operator=(const URIPath &_path)
-{
-  this->dataPtr->path = _path.dataPtr->path;
-  this->dataPtr->isAbsolute = _path.dataPtr->isAbsolute;
-  return *this;
-}
-
-/////////////////////////////////////////////////
 void URIPath::Clear()
 {
   this->dataPtr->path.clear();
@@ -673,7 +629,7 @@ bool URIPath::Parse(const std::string &_str)
 
 /////////////////////////////////////////////////
 URIQuery::URIQuery()
-  : dataPtr(new URIQueryPrivate())
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
 }
 
@@ -689,28 +645,9 @@ URIQuery::URIQuery(const std::string &_str)
 }
 
 /////////////////////////////////////////////////
-URIQuery::URIQuery(const URIQuery &_query)
-  : URIQuery()
-{
-  *this = _query;
-}
-
-/////////////////////////////////////////////////
-URIQuery::~URIQuery()
-{
-}
-
-/////////////////////////////////////////////////
 void URIQuery::Insert(const std::string &_key, const std::string &_value)
 {
   this->dataPtr->values.push_back(std::make_pair(_key, _value));
-}
-
-/////////////////////////////////////////////////
-URIQuery &URIQuery::operator=(const URIQuery &_query)
-{
-  this->dataPtr->values = _query.dataPtr->values;
-  return *this;
 }
 
 /////////////////////////////////////////////////
@@ -808,7 +745,7 @@ bool URIQuery::Parse(const std::string &_str)
 
 /////////////////////////////////////////////////
 URIFragment::URIFragment()
-  : dataPtr(new URIFragmentPrivate())
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
 }
 
@@ -821,25 +758,6 @@ URIFragment::URIFragment(const std::string &_str)
     ignwarn << "Unable to parse URIFragment [" << _str << "]. Ignoring."
            << std::endl;
   }
-}
-
-/////////////////////////////////////////////////
-URIFragment::URIFragment(const URIFragment &_fragment)
-  : URIFragment()
-{
-  *this = _fragment;
-}
-
-/////////////////////////////////////////////////
-URIFragment::~URIFragment()
-{
-}
-
-/////////////////////////////////////////////////
-URIFragment &URIFragment::operator=(const URIFragment &_fragment)
-{
-  this->dataPtr->value = _fragment.dataPtr->value;
-  return *this;
 }
 
 /////////////////////////////////////////////////
@@ -925,7 +843,7 @@ bool URIFragment::Parse(const std::string &_str)
 
 /////////////////////////////////////////////////
 URI::URI()
-  : dataPtr(new URIPrivate())
+  : dataPtr(ignition::utils::MakeImpl<Implementation>())
 {
 }
 
@@ -944,18 +862,6 @@ URI::URI(const std::string &_str, bool _hasAuthority)
   }
 
   this->Parse(_str);
-}
-
-/////////////////////////////////////////////////
-URI::URI(const URI &_uri)
-  : URI()
-{
-  *this = _uri;
-}
-
-/////////////////////////////////////////////////
-URI::~URI()
-{
 }
 
 //////////////////////////////////////////////////
@@ -1062,17 +968,6 @@ bool URI::operator==(const URI &_uri) const
          this->dataPtr->path == _uri.dataPtr->path &&
          this->dataPtr->query == _uri.dataPtr->query &&
          this->dataPtr->fragment == _uri.dataPtr->fragment;
-}
-
-/////////////////////////////////////////////////
-URI &URI::operator=(const URI &_uri)
-{
-  this->dataPtr->scheme = _uri.dataPtr->scheme;
-  this->dataPtr->authority = _uri.dataPtr->authority;
-  this->dataPtr->path = _uri.dataPtr->path;
-  this->dataPtr->query = _uri.dataPtr->query;
-  this->dataPtr->fragment = _uri.dataPtr->fragment;
-  return *this;
 }
 
 /////////////////////////////////////////////////

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -890,8 +890,8 @@ TEST(URITEST, HasAuthority)
     // Modifyng path updates string
     uri.Path() = URIPath("new_authority.com/another/path");
 
-    EXPECT_EQ("new_authority.com/another/path/", uri.Path().Str());
-    EXPECT_EQ("https://new_authority.com/another/path/", uri.Str());
+    EXPECT_EQ("new_authority.com/another/path", uri.Path().Str());
+    EXPECT_EQ("https://new_authority.com/another/path", uri.Str());
 
     // Clearing keeps false authority
     uri.Clear();

--- a/src/WorkerPool.cc
+++ b/src/WorkerPool.cc
@@ -52,7 +52,7 @@ namespace ignition
     };
 
     /// \brief Private implementation
-    class WorkerPoolPrivate
+    class WorkerPool::Implementation
     {
       /// \brief Does work until signaled to shut down
       public: void Worker();
@@ -82,7 +82,7 @@ namespace ignition
 }
 
 //////////////////////////////////////////////////
-void WorkerPoolPrivate::Worker()
+void WorkerPool::Implementation::Worker()
 {
   WorkOrder order;
 
@@ -125,7 +125,7 @@ void WorkerPoolPrivate::Worker()
 
 //////////////////////////////////////////////////
 WorkerPool::WorkerPool(const unsigned int _minThreadCount)
-  : dataPtr(new WorkerPoolPrivate)
+  : dataPtr(ignition::utils::MakeUniqueImpl<Implementation>())
 {
   unsigned int numWorkers = std::max(std::thread::hardware_concurrency(),
       std::max(_minThreadCount, 1u));
@@ -134,7 +134,7 @@ WorkerPool::WorkerPool(const unsigned int _minThreadCount)
   for (unsigned int w = 0; w < numWorkers; ++w)
   {
     this->dataPtr->workers.push_back(
-        std::thread(&WorkerPoolPrivate::Worker, this->dataPtr.get()));
+        std::thread(&WorkerPool::Implementation::Worker, this->dataPtr.get()));
   }
 }
 


### PR DESCRIPTION
Since we can add a dependency on `ign-utils1`, update to use the `ImplPtr` pattern instead of `std::unique_ptr` where relevant.

**Note to maintainers**: Remember to use **Squash-Merge**
