### PR TITLE
Fix bug in URIPath assignment operator

### DIFF
--- a/src/URI.cc
+++ b/src/URI.cc
@@ -587,6 +587,7 @@ URIPath &URIPath::operator=(const URIPath &_path)
 {
   this->dataPtr->path = _path.dataPtr->path;
   this->dataPtr->isAbsolute = _path.dataPtr->isAbsolute;
+  this->dataPtr->trailingSlash = _path.dataPtr->trailingSlash;
   return *this;
 }
 

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -890,8 +890,8 @@ TEST(URITEST, HasAuthority)
     // Modifyng path updates string
     uri.Path() = URIPath("new_authority.com/another/path");
 
-    EXPECT_EQ("new_authority.com/another/path/", uri.Path().Str());
-    EXPECT_EQ("https://new_authority.com/another/path/", uri.Str());
+    EXPECT_EQ("new_authority.com/another/path", uri.Path().Str());
+    EXPECT_EQ("https://new_authority.com/another/path", uri.Str());
 
     // Clearing keeps false authority
     uri.Clear();


### PR DESCRIPTION
# 🦟 Bug fix

Discovered in #274.

## Summary

The issue is that the `URIPath::Implementation` struct has a `trailingSlash` member: https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI.cc#L54-L73

The originally written copy-assignment operator doesn't copy this member:
https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI.cc#L586-L591

And the test exercises this copy-assignment: 
https://github.com/ignitionrobotics/ign-common/blob/ign-common4/src/URI_TEST.cc#L890-L894

In this case, `ImplPtr` has shown that the previous behavior is actually a bug, and we should fix it in previous versions.

**Note to maintainers**: Remember to use **Squash-Merge**
