### PR TITLE
Fixed crash when a Collada file has an empty normal vector

### DIFF
--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -2248,8 +2248,11 @@ void ColladaLoader::Implementation::LoadPolylist(
               inputRemappedNormalIndex = normalDupMap[inputRemappedNormalIndex];
             }
 
-            subMesh->AddNormal(norms[inputRemappedNormalIndex]);
-            input.normalIndex = inputRemappedNormalIndex;
+            if (norms.size() < inputRemappedNormalIndex)
+            {
+              subMesh->AddNormal(norms[inputRemappedNormalIndex]);
+              input.normalIndex = inputRemappedNormalIndex;
+            }
           }
 
           if (!inputs[TEXCOORD].empty())

--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -2370,7 +2370,8 @@ void ColladaLoader::Implementation::LoadTriangles(
       this->LoadNormals(source, _transform, norms, normalDupMap);
       combinedVertNorms = false;
       inputs[NORMAL].insert(ignition::math::parseInt(offset));
-      hasNormals = true;
+      if (norms.size() > 0)
+        hasNormals = true;
     }
     else if (semantic == "TEXCOORD")
     {

--- a/graphics/src/ColladaLoader.cc
+++ b/graphics/src/ColladaLoader.cc
@@ -2248,7 +2248,7 @@ void ColladaLoader::Implementation::LoadPolylist(
               inputRemappedNormalIndex = normalDupMap[inputRemappedNormalIndex];
             }
 
-            if (norms.size() < inputRemappedNormalIndex)
+            if (norms.size() > inputRemappedNormalIndex)
             {
               subMesh->AddNormal(norms[inputRemappedNormalIndex]);
               input.normalIndex = inputRemappedNormalIndex;


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

# 🦟 Bug fix

## Summary

If a collada file has defined normals but these are empty, then Ignition will crash. This should fix this crash

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
