### PR TITLE
Try to checkout matching branch in macos workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,6 +17,21 @@ jobs:
     - name: Install base dependencies
       run: |
         brew tap osrf/simulation;
+        # check for ci_matching_branch
+        brew install wget
+        wget https://github.com/ignition-tooling/release-tools/raw/master/jenkins-scripts/tools/detect_ci_matching_branch.py
+        TRY_BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+        if python3 detect_ci_matching_branch.py ${TRY_BRANCH}
+        then
+          echo "# BEGIN SECTION: trying to checkout branch ${TRY_BRANCH} from osrf/simulation"
+          pushd $(brew --repo osrf/simulation)
+          git fetch origin ${TRY_BRANCH} || true
+          git checkout ${TRY_BRANCH} || true
+          popd
+          echo '# END SECTION'
+        fi
+        # ignition-math7 has problems with swig, remove it for now
+        brew remove swig || true
         brew install --only-dependencies ${PACKAGE};
     - run: mkdir build
     - name: cmake


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/ignition-tooling/release-tools/issues/564

## Summary

Copy changes for checking out matching branches in macOS workflow from https://github.com/ignitionrobotics/sdformat/pull/803

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
