### PR TITLE
Move geospatial headers to subfolder

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -18,7 +18,7 @@ release will remove the deprecated code.
 `graphics` component and into the new `geospatial` component
     + To use the heightmap features, users must add the `geospatial` component
       to the `find_package` call and update the include paths to use
-      the geospatial subfolder (`#include <ignition/common/geospatial/Dem.hh>`)
+      the geospatial subfolder (`#include <ignition/common/geospatial/HeightmapData.hh>`)
 
 ## Ignition Common 3.X to 4.X
 

--- a/Migration.md
+++ b/Migration.md
@@ -17,7 +17,8 @@ release will remove the deprecated code.
 1. `HeightmapData.hh` and `ImageHeightmap.hh` have been moved out of the
 `graphics` component and into the new `geospatial` component
     + To use the heightmap features, users must add the `geospatial` component
-      to the `find_package` call
+      to the `find_package` call and update the include paths to use
+      the geospatial subfolder (`#include <ignition/common/geospatial/Dem.hh>`)
 
 ## Ignition Common 3.X to 4.X
 

--- a/geospatial/include/ignition/common/geospatial/Dem.hh
+++ b/geospatial/include/ignition/common/geospatial/Dem.hh
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_COMMON_DEM_HH_
-#define IGNITION_COMMON_DEM_HH_
+#ifndef IGNITION_COMMON_GEOSPATIAL_DEM_HH_
+#define IGNITION_COMMON_GEOSPATIAL_DEM_HH_
 
 #include <memory>
 #include <string>
@@ -24,8 +24,8 @@
 #include <ignition/math/Vector3.hh>
 #include <ignition/math/Angle.hh>
 
-#include <ignition/common/HeightmapData.hh>
-#include <ignition/common/graphics/Export.hh>
+#include <ignition/common/geospatial/Export.hh>
+#include <ignition/common/geospatial/HeightmapData.hh>
 
 #include <ignition/utils/ImplPtr.hh>
 
@@ -36,7 +36,7 @@ namespace ignition
   {
     /// \class DEM DEM.hh common/common.hh
     /// \brief Encapsulates a DEM (Digital Elevation Model) file.
-    class IGNITION_COMMON_GRAPHICS_VISIBLE Dem : public HeightmapData
+    class IGNITION_COMMON_GEOSPATIAL_VISIBLE Dem : public HeightmapData
     {
       /// \brief Constructor.
       public: Dem();

--- a/geospatial/include/ignition/common/geospatial/HeightmapData.hh
+++ b/geospatial/include/ignition/common/geospatial/HeightmapData.hh
@@ -14,20 +14,20 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_COMMON_HEIGHTMAPDATA_HH_
-#define IGNITION_COMMON_HEIGHTMAPDATA_HH_
+#ifndef IGNITION_COMMON_GEOSPATIAL_HEIGHTMAPDATA_HH_
+#define IGNITION_COMMON_GEOSPATIAL_HEIGHTMAPDATA_HH_
 
 #include <string>
 #include <vector>
 #include <ignition/math/Vector3.hh>
-#include <ignition/common/graphics/Export.hh>
+#include <ignition/common/geospatial/Export.hh>
 
 namespace ignition
 {
   namespace common
   {
     /// \brief Encapsulates a generic heightmap data file.
-    class IGNITION_COMMON_GRAPHICS_VISIBLE HeightmapData
+    class IGNITION_COMMON_GEOSPATIAL_VISIBLE HeightmapData
     {
       /// \brief Destructor.
       public: virtual ~HeightmapData() = default;

--- a/geospatial/include/ignition/common/geospatial/ImageHeightmap.hh
+++ b/geospatial/include/ignition/common/geospatial/ImageHeightmap.hh
@@ -14,16 +14,16 @@
  * limitations under the License.
  *
 */
-#ifndef IGNITION_COMMON_IMAGEHEIGHTMAPDATA_HH_
-#define IGNITION_COMMON_IMAGEHEIGHTMAPDATA_HH_
+#ifndef IGNITION_COMMON_GEOSPATIAL_IMAGEHEIGHTMAPDATA_HH_
+#define IGNITION_COMMON_GEOSPATIAL_IMAGEHEIGHTMAPDATA_HH_
 
 #include <limits>
 #include <string>
 #include <vector>
 #include <ignition/math/Vector3.hh>
 
-#include <ignition/common/graphics/Export.hh>
-#include <ignition/common/HeightmapData.hh>
+#include <ignition/common/geospatial/Export.hh>
+#include <ignition/common/geospatial/HeightmapData.hh>
 #include <ignition/common/Image.hh>
 
 namespace ignition
@@ -31,7 +31,7 @@ namespace ignition
   namespace common
   {
     /// \brief Encapsulates an image that will be interpreted as a heightmap.
-    class IGNITION_COMMON_GRAPHICS_VISIBLE ImageHeightmap
+    class IGNITION_COMMON_GEOSPATIAL_VISIBLE ImageHeightmap
       : public ignition::common::HeightmapData
     {
       /// \brief Constructor

--- a/geospatial/src/Dem.cc
+++ b/geospatial/src/Dem.cc
@@ -21,7 +21,7 @@
 #include <ogr_spatialref.h>
 
 #include "ignition/common/Console.hh"
-#include "ignition/common/Dem.hh"
+#include "ignition/common/geospatial/Dem.hh"
 #include "ignition/math/SphericalCoordinates.hh"
 
 using namespace ignition;

--- a/geospatial/src/Dem_TEST.cc
+++ b/geospatial/src/Dem_TEST.cc
@@ -20,7 +20,7 @@
 #include <ignition/math/Angle.hh>
 #include <ignition/math/Vector3.hh>
 
-#include "ignition/common/Dem.hh"
+#include "ignition/common/geospatial/Dem.hh"
 #include "test_config.h"
 
 using namespace ignition;

--- a/geospatial/src/ImageHeightmap.cc
+++ b/geospatial/src/ImageHeightmap.cc
@@ -15,7 +15,7 @@
  *
  */
 #include "ignition/common/Console.hh"
-#include "ignition/common/ImageHeightmap.hh"
+#include "ignition/common/geospatial/ImageHeightmap.hh"
 
 using namespace ignition;
 using namespace common;

--- a/geospatial/src/ImageHeightmap_TEST.cc
+++ b/geospatial/src/ImageHeightmap_TEST.cc
@@ -16,7 +16,7 @@
 */
 #include <gtest/gtest.h>
 
-#include "ignition/common/ImageHeightmap.hh"
+#include "ignition/common/geospatial/ImageHeightmap.hh"
 #include "test_config.h"
 
 #define ELEVATION_TOL 1e-8


### PR DESCRIPTION
# 🦟 Bug fix

Follow-up to #267, connected to https://github.com/ignition-release/ign-common5-release/pull/4

## Summary

This simplifies the logic required for packaging by putting all the geospatial header files in a subfolder. We haven't done this for the other ing-common components, but now is an easy time to do it for geospatial since we are already breaking things with this component.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
