### PR TITLE
Miscellaneous cleanup of Events API

### DIFF
--- a/events/include/ignition/common/Event.hh
+++ b/events/include/ignition/common/Event.hh
@@ -53,7 +53,7 @@ namespace ignition
 
       /// \brief Set whether this event has been signaled.
       /// \param[in] _sig True if the event has been signaled.
-      public: void SetSignaled(const bool _sig);
+      public: void SetSignaled(bool _sig);
 
       /// \brief True if the event has been signaled.
       private: bool signaled;
@@ -65,7 +65,7 @@ namespace ignition
       /// \brief Constructor.
       /// \param[in] _e Event pointer to connect with.
       /// \param[in] _i Unique id.
-      public: Connection(Event *_e, const int _i);
+      public: Connection(Event *_e, int _i);
 
       /// \brief Destructor.
       public: ~Connection();
@@ -156,7 +156,7 @@ namespace ignition
       private: class EventConnection
       {
         /// \brief Constructor
-        public: EventConnection(const bool _on, const std::function<T> &_cb,
+        public: EventConnection(bool _on, const std::function<T> &_cb,
                         const ConnectionPtr &_publicConn)
             : callback(_cb), publicConnection(_publicConn)
         {

--- a/events/include/ignition/common/KeyEvent.hh
+++ b/events/include/ignition/common/KeyEvent.hh
@@ -57,7 +57,7 @@ namespace ignition
 
       /// \brief Set the event type
       /// \param[in] _type Event type
-      public: void SetType(const EventType _type);
+      public: void SetType(EventType _type);
 
       /// \brief Get the key number
       /// \return The key number
@@ -65,7 +65,7 @@ namespace ignition
 
       /// \brief Set the key
       /// \param[in] _key The key number
-      public: void SetKey(const int _key);
+      public: void SetKey(int _key);
 
       /// \brief Get the formatted string of the key pressed (could be
       /// uppercase).
@@ -82,7 +82,7 @@ namespace ignition
 
       /// \brief Set whether the control key was held during this key event
       /// \param[in] _control Status of the control key
-      public: void SetControl(const bool _control);
+      public: void SetControl(bool _control);
 
       /// \brief Get whether the shift key was held during this key event
       /// \return True if the shift key was pressed
@@ -90,7 +90,7 @@ namespace ignition
 
       /// \brief Set whether the shift key was held during this key event
       /// \param[in] _shift Status of the shift key
-      public: void SetShift(const bool _shift);
+      public: void SetShift(bool _shift);
 
       /// \brief Get whether the alt key was held during this key event
       /// \return True if the alt key was pressed
@@ -98,7 +98,7 @@ namespace ignition
 
       /// \brief Set whether the alt key was held during this key event
       /// \param[in] _alt Status of the alt key
-      public: void SetAlt(const bool _alt);
+      public: void SetAlt(bool _alt);
 
       /// \brief Assignment operator
       /// \param[in] _other Other key event

--- a/events/include/ignition/common/MouseEvent.hh
+++ b/events/include/ignition/common/MouseEvent.hh
@@ -90,7 +90,7 @@ namespace ignition
       /// \brief Set mouse pointer position on the screen.
       /// \param[in] _x Mouse pointer X position on the screen.
       /// \param[in] _y Mouse pointer Y position on the screen.
-      public: void SetPos(const int _x, const int _y);
+      public: void SetPos(int _x, int _y);
 
       /// \brief Get the previous position.
       /// \return The previous mouse position.
@@ -103,7 +103,7 @@ namespace ignition
       /// \brief Set the previous position.
       /// \param[in] _x Previous mouse pointer X position on the screen.
       /// \param[in] _y Previous mouse pointer Y position on the screen.
-      public: void SetPrevPos(const int _x, const int _y);
+      public: void SetPrevPos(int _x, int _y);
 
       /// \brief Get the position of button press.
       /// \return Screen position of a button press.
@@ -116,7 +116,7 @@ namespace ignition
       /// \brief Set the position of button press.
       /// \param[in] _x Mouse pointer X position on the screen.
       /// \param[in] _y Mouse pointer Y position on the screen.
-      public: void SetPressPos(const int _x, const int _y);
+      public: void SetPressPos(int _x, int _y);
 
       /// \brief Get the scroll position.
       /// \return The scroll position.
@@ -129,7 +129,7 @@ namespace ignition
       /// \brief Set the scroll position.
       /// \param[in] _x Scroll X position.
       /// \param[in] _y Scroll Y position.
-      public: void SetScroll(const int _x, const int _y);
+      public: void SetScroll(int _x, int _y);
 
       /// \brief Get the scaling factor.
       /// \return The move scaling factor.
@@ -137,7 +137,7 @@ namespace ignition
 
       /// \brief Set the scaling factor.
       /// \param[in] _scale The move scaling factor.
-      public: void SetMoveScale(const float _scale);
+      public: void SetMoveScale(float _scale);
 
       /// \brief Get the flag for mouse drag motion
       /// \return True if dragging, usually indicating a mouse move with
@@ -146,7 +146,7 @@ namespace ignition
 
       /// \brief Set the flag for mouse drag motion
       /// \param[in] _dragging The dragging flag.
-      public: void SetDragging(const bool _dragging);
+      public: void SetDragging(bool _dragging);
 
       /// \brief Get the event type.
       /// \return The EventType.
@@ -154,7 +154,7 @@ namespace ignition
 
       /// \brief Set the event type.
       /// \param[in] _type The EventType.
-      public: void SetType(const EventType _type) const;
+      public: void SetType(MouseEvent::EventType _type) const;
 
       /// \brief Get the button which caused this event.
       /// \return The button which caused this event.
@@ -162,7 +162,7 @@ namespace ignition
 
       /// \brief Set the button which caused the event.
       /// \param[in] _button The button which caused this event.
-      public: void SetButton(const MouseEvent::MouseButton _button) const;
+      public: void SetButton(MouseEvent::MouseButton _button) const;
 
       /// \brief Get the state of the buttons when the event was generated.
       /// \return The state of the buttons, which can be a bitwise
@@ -172,7 +172,7 @@ namespace ignition
       /// \brief Set the state of the buttons when the event was generated.
       /// \param[in] _buttons The state of the buttons, which can be a bitwise
       /// combination of MouseEvent::MouseButton.
-      public: void SetButtons(const unsigned int &_buttons);
+      public: void SetButtons(unsigned int _buttons);
 
       /// \brief Get the shift key press flag.
       /// \return True if the shift key is pressed.
@@ -180,7 +180,7 @@ namespace ignition
 
       /// \brief Set the shift key press flag.
       /// \param[in] _shift The shift key press flag.
-      public: void SetShift(const bool _shift) const;
+      public: void SetShift(bool _shift) const;
 
       /// \brief Get the alt key press flag.
       /// \return True if the alt key is pressed.
@@ -188,7 +188,7 @@ namespace ignition
 
       /// \brief Set the alt key press flag.
       /// \param[in] _alt The alt key flag.
-      public: void SetAlt(const bool _alt);
+      public: void SetAlt(bool _alt);
 
       /// \brief Get the control key press flag.
       /// \return True if the control key is pressed.
@@ -196,7 +196,7 @@ namespace ignition
 
       /// \brief Set the control key press flag.
       /// \param[in] _control The control key flag.
-      public: void SetControl(const bool _control) const;
+      public: void SetControl(bool _control) const;
 
       /// \brief Assignment operator
       /// \param[in] _other Other mouse event

--- a/events/include/ignition/common/MouseEvent.hh
+++ b/events/include/ignition/common/MouseEvent.hh
@@ -154,7 +154,7 @@ namespace ignition
 
       /// \brief Set the event type.
       /// \param[in] _type The EventType.
-      public: void SetType(MouseEvent::EventType _type) const;
+      public: void SetType(MouseEvent::EventType _type);
 
       /// \brief Get the button which caused this event.
       /// \return The button which caused this event.
@@ -162,7 +162,7 @@ namespace ignition
 
       /// \brief Set the button which caused the event.
       /// \param[in] _button The button which caused this event.
-      public: void SetButton(MouseEvent::MouseButton _button) const;
+      public: void SetButton(MouseEvent::MouseButton _button);
 
       /// \brief Get the state of the buttons when the event was generated.
       /// \return The state of the buttons, which can be a bitwise
@@ -180,7 +180,7 @@ namespace ignition
 
       /// \brief Set the shift key press flag.
       /// \param[in] _shift The shift key press flag.
-      public: void SetShift(bool _shift) const;
+      public: void SetShift(bool _shift);
 
       /// \brief Get the alt key press flag.
       /// \return True if the alt key is pressed.
@@ -196,7 +196,7 @@ namespace ignition
 
       /// \brief Set the control key press flag.
       /// \param[in] _control The control key flag.
-      public: void SetControl(bool _control) const;
+      public: void SetControl(bool _control);
 
       /// \brief Assignment operator
       /// \param[in] _other Other mouse event

--- a/events/src/Event.cc
+++ b/events/src/Event.cc
@@ -39,13 +39,13 @@ bool Event::Signaled() const
 }
 
 //////////////////////////////////////////////////
-void Event::SetSignaled(const bool _sig)
+void Event::SetSignaled(bool _sig)
 {
   this->signaled = _sig;
 }
 
 //////////////////////////////////////////////////
-Connection::Connection(Event *_e, const int _i)
+Connection::Connection(Event *_e, int _i)
 : event(_e), id(_i)
 {
   this->creationTime = IGN_SYSTEM_TIME();

--- a/events/src/KeyEvent.cc
+++ b/events/src/KeyEvent.cc
@@ -25,7 +25,7 @@ class ignition::common::KeyEventPrivate
   public: KeyEvent::EventType type = KeyEvent::NO_EVENT;
 
   /// \brief The raw value of the key pressed.
-  public:  int key = 0;
+  public: int key = 0;
 
   /// \brief Formatted string of the key pressed (could be uppercase).
   public: std::string text = "";
@@ -72,7 +72,7 @@ KeyEvent::EventType KeyEvent::Type() const
 }
 
 /////////////////////////////////////////////////
-void KeyEvent::SetType(const KeyEvent::EventType _type)
+void KeyEvent::SetType(KeyEvent::EventType _type)
 {
   this->dataPtr->type = _type;
 }
@@ -84,7 +84,7 @@ int KeyEvent::Key() const
 }
 
 /////////////////////////////////////////////////
-void KeyEvent::SetKey(const int _key)
+void KeyEvent::SetKey(int _key)
 {
   this->dataPtr->key = _key;
 }
@@ -108,7 +108,7 @@ bool KeyEvent::Control() const
 }
 
 /////////////////////////////////////////////////
-void KeyEvent::SetControl(const bool _control)
+void KeyEvent::SetControl(bool _control)
 {
   this->dataPtr->control = _control;
 }
@@ -120,7 +120,7 @@ bool KeyEvent::Shift() const
 }
 
 /////////////////////////////////////////////////
-void KeyEvent::SetShift(const bool _shift)
+void KeyEvent::SetShift(bool _shift)
 {
   this->dataPtr->shift = _shift;
 }
@@ -132,7 +132,7 @@ bool KeyEvent::Alt() const
 }
 
 /////////////////////////////////////////////////
-void KeyEvent::SetAlt(const bool _alt)
+void KeyEvent::SetAlt(bool _alt)
 {
   this->dataPtr->alt = _alt;
 }

--- a/events/src/MouseEvent.cc
+++ b/events/src/MouseEvent.cc
@@ -100,7 +100,7 @@ void MouseEvent::SetPos(const ignition::math::Vector2i &_pos)
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetPos(const int _x, const int _y)
+void MouseEvent::SetPos(int _x, int _y)
 {
   this->dataPtr->pos.Set(_x, _y);
 }
@@ -118,7 +118,7 @@ void MouseEvent::SetPrevPos(const ignition::math::Vector2i &_pos)
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetPrevPos(const int _x, const int _y)
+void MouseEvent::SetPrevPos(int _x, int _y)
 {
   this->dataPtr->prevPos.Set(_x, _y);
 }
@@ -136,7 +136,7 @@ void MouseEvent::SetPressPos(const ignition::math::Vector2i &_pos)
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetPressPos(const int _x, const int _y)
+void MouseEvent::SetPressPos(int _x, int _y)
 {
   this->dataPtr->pressPos.Set(_x, _y);
 }
@@ -154,7 +154,7 @@ void MouseEvent::SetScroll(const ignition::math::Vector2i &_scroll)
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetScroll(const int _x, const int _y)
+void MouseEvent::SetScroll(int _x, int _y)
 {
   this->dataPtr->scroll.Set(_x, _y);
 }
@@ -166,7 +166,7 @@ float MouseEvent::MoveScale() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetMoveScale(const float _scale)
+void MouseEvent::SetMoveScale(float _scale)
 {
   this->dataPtr->moveScale = _scale;
 }
@@ -178,7 +178,7 @@ bool MouseEvent::Dragging() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetDragging(const bool _dragging)
+void MouseEvent::SetDragging(bool _dragging)
 {
   this->dataPtr->dragging = _dragging;
 }
@@ -190,7 +190,7 @@ MouseEvent::EventType MouseEvent::Type() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetType(const EventType _type) const
+void MouseEvent::SetType(MouseEvent::EventType _type) const
 {
   this->dataPtr->type = _type;
 }
@@ -202,7 +202,7 @@ MouseEvent::MouseButton MouseEvent::Button() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetButton(const MouseEvent::MouseButton _button) const
+void MouseEvent::SetButton(MouseEvent::MouseButton _button) const
 {
   this->dataPtr->button = _button;
 }
@@ -214,7 +214,7 @@ unsigned int MouseEvent::Buttons() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetButtons(const unsigned int &_buttons)
+void MouseEvent::SetButtons(unsigned int _buttons)
 {
   this->dataPtr->buttons = _buttons;
 }
@@ -226,7 +226,7 @@ bool MouseEvent::Shift() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetShift(const bool _shift) const
+void MouseEvent::SetShift(bool _shift) const
 {
   this->dataPtr->shift = _shift;
 }
@@ -238,7 +238,7 @@ bool MouseEvent::Alt() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetAlt(const bool _alt)
+void MouseEvent::SetAlt(bool _alt)
 {
   this->dataPtr->alt = _alt;
 }
@@ -250,7 +250,7 @@ bool MouseEvent::Control() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetControl(const bool _control) const
+void MouseEvent::SetControl(bool _control) const
 {
   this->dataPtr->control = _control;
 }

--- a/events/src/MouseEvent.cc
+++ b/events/src/MouseEvent.cc
@@ -190,7 +190,7 @@ MouseEvent::EventType MouseEvent::Type() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetType(MouseEvent::EventType _type) const
+void MouseEvent::SetType(MouseEvent::EventType _type)
 {
   this->dataPtr->type = _type;
 }
@@ -202,7 +202,7 @@ MouseEvent::MouseButton MouseEvent::Button() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetButton(MouseEvent::MouseButton _button) const
+void MouseEvent::SetButton(MouseEvent::MouseButton _button)
 {
   this->dataPtr->button = _button;
 }
@@ -226,7 +226,7 @@ bool MouseEvent::Shift() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetShift(bool _shift) const
+void MouseEvent::SetShift(bool _shift)
 {
   this->dataPtr->shift = _shift;
 }
@@ -250,7 +250,7 @@ bool MouseEvent::Control() const
 }
 
 /////////////////////////////////////////////////
-void MouseEvent::SetControl(bool _control) const
+void MouseEvent::SetControl(bool _control)
 {
   this->dataPtr->control = _control;
 }


### PR DESCRIPTION
There were two issues with the Events API:

1. There were several places where we were using `const primitive` arguments to functions. https://clang.llvm.org/extra/clang-tidy/checks/readability-avoid-const-params-in-decls.html
2. There were several places where we marked a `SetXXX` function as `const` where we mutated internal data, breaking const-correctness.

These are split in two commits for easier review.