### PR TITLE
Fix out-of-bounds access in sanitizeSlashes

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -290,7 +290,7 @@ std::string ignition::common::joinPaths(const std::string &_path1,
 
     // Sanitize the end of the path.
     index = result.length()-1;
-    for (; result[index] == replacement; --index)
+    for (; index <  result.length() && result[index] == replacement; --index)
     {
     }
     index += 1;

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -282,7 +282,7 @@ std::string ignition::common::joinPaths(const std::string &_path1,
     // Sanitize the start of the path.
     size_t index = 0;
     size_t leadingIndex = _stripLeading ? 0 : 1;
-    for (; result[index] == replacement; ++index)
+    for (; index < result.length() && result[index] == replacement; ++index)
     {
     }
     if (index > leadingIndex)


### PR DESCRIPTION
Fixes #301

Before this fix:

- Expected behavior: Tests build and run when -D_GLIBCXX_ASSERTIONS is set
- Actual behavior: Test aborts due to out-of-bounds access

Steps to reproduce

```
git checkout ign-common4
CXXFLAGS=-D_GLIBCXX_ASSERTIONS cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug
make -C build UNIT_Filesystem_TEST
./build/bin/UNIT_Filesystem_TEST
gdb -ex run ./build/bin/UNIT_Filesystem_TEST
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>