### PR TITLE
Jennuine/parent path

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -209,6 +209,10 @@ std::string ignition::common::parentPath(const std::string &_path)
   // Maintain compatibility with ign-common
   if (*_path.rbegin() == fs::path::preferred_separator)
     p = fs::path(_path.substr(0, _path.size()-1));
+
+  if (!p.has_parent_path())
+    return p.string();
+
   return p.parent_path().string();
 }
 

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -211,7 +211,7 @@ std::string ignition::common::parentPath(const std::string &_path)
     p = fs::path(_path.substr(0, _path.size()-1));
 
   if (!p.has_parent_path())
-    return p.string();
+    return _path;
 
   return p.parent_path().string();
 }

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -473,6 +473,9 @@ TEST_F(FilesystemTest, parentPath)
   child_with_slash = separator(child_with_slash);
   std::string parent2 = parentPath(child_with_slash);
   EXPECT_EQ(parent, parent2);
+
+  std::string childOnly = "child";
+  EXPECT_EQ(childOnly, parentPath(childOnly));
 }
 
 /////////////////////////////////////////////////

--- a/src/Timer.cc
+++ b/src/Timer.cc
@@ -24,10 +24,10 @@ using namespace common;
 class ignition::common::Timer::Implementation
 {
   /// \brief The time of the last call to Start
-  public: std::chrono::steady_clock::time_point start; 
+  public: std::chrono::steady_clock::time_point start;
 
   /// \brief The time when Stop was called.
-  public: std::chrono::steady_clock::time_point stop; 
+  public: std::chrono::steady_clock::time_point stop;
 
   /// \brief True if the timer is running.
   public: bool running {false};
@@ -71,7 +71,7 @@ std::chrono::duration<double> Timer::ElapsedTime() const
   }
   else
   {
-    std::chrono::duration<double> diff = 
+    std::chrono::duration<double> diff =
       this->dataPtr->stop - this->dataPtr->start;
     return diff;
   }

--- a/src/Timer_TEST.cc
+++ b/src/Timer_TEST.cc
@@ -66,7 +66,7 @@ TEST(Timer_TEST, Copy)
   ignition::common::Timer t2 = t1;
   EXPECT_TRUE(t2.Running());
 
-  // Stop the original 
+  // Stop the original
   t1.Stop();
   EXPECT_FALSE(t1.Running());
   EXPECT_TRUE(t2.Running());

--- a/src/Util.cc
+++ b/src/Util.cc
@@ -64,7 +64,7 @@
 /// destruction order fiasco issues.
 ignition::common::SystemPaths& GetSystemPaths()
 {
-  static 
+  static
     ignition::utils::NeverDestroyed<ignition::common::SystemPaths> paths;
   return paths.Access();
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
With the `parentPath` updates from https://github.com/ignitionrobotics/ign-common/pull/238 , `parentPath` returns an empty string when there is no parent. This caused [`INTEGRATION_camera_video_record_system test`](https://github.com/ignitionrobotics/ign-gazebo/blob/4a5a33dca43aa12ad84453082125f9d6ab1bf47b/test/integration/camera_video_record_system.cc) to fail. I added a fix to match the behavior from `ign-common5`. Feel free to close if [ign-gazebo's `CameraVideoRecorder`](https://github.com/ignitionrobotics/ign-gazebo/blob/faaa3ec2c9006db0be71be318e7f00be51d2a8e3/src/systems/camera_video_recorder/CameraVideoRecorder.cc#L405-L411) should be fixed instead.

Also, fixed some codecheck errors. I wonder why it's not being picked up by our linters?

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.