### PR TITLE
Fix filesystem::separator behavior

### DIFF
--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -99,8 +99,7 @@ bool ignition::common::createDirectories(const std::string &_path)
 /////////////////////////////////////////////////
 std::string const ignition::common::separator(std::string const &_s)
 {
-  fs::path path(_s);
-  return (_s / fs::path("")).string();
+  return _s + std::string{fs::path::preferred_separator};
 }
 
 /////////////////////////////////////////////////
@@ -143,6 +142,11 @@ std::string ignition::common::joinPaths(
 {
   fs::path p1{_path1};
   fs::path p2{_path2};
+
+  if (p1.empty())
+  {
+    p1 = ignition::common::separator("");
+  }
 
   bool is_url = false;
 
@@ -201,25 +205,24 @@ bool ignition::common::chdir(const std::string &_dir)
 /////////////////////////////////////////////////
 std::string ignition::common::basename(const std::string &_path)
 {
-  fs::path p(_path);
-  // Maintain compatibility with ign-common
-  if (*_path.rbegin() == fs::path::preferred_separator)
-    p = fs::path(_path.substr(0, _path.size()-1));
-  return p.filename().string();
+  fs::path p = fs::path(_path);
+  p /= "FOO.TXT";
+  p = p.lexically_normal();
+  p = p.parent_path();
+  return p.filename().string().empty() ? 
+    std::string{fs::path::preferred_separator} : p.filename().string();
 }
 
 /////////////////////////////////////////////////
 std::string ignition::common::parentPath(const std::string &_path)
 {
-  fs::path p(_path);
-  // Maintain compatibility with ign-common
-  if (*_path.rbegin() == fs::path::preferred_separator)
-    p = fs::path(_path.substr(0, _path.size()-1));
-
-  if (!p.has_parent_path())
-    return _path;
-
-  return p.parent_path().string();
+  std::string result;
+  size_t last_sep = _path.find_last_of(separator(""));
+  // If slash is the last character, find its parent directory
+  if (last_sep == _path.length() - 1)
+    last_sep = _path.substr(0, last_sep).find_last_of(separator(""));
+  result = _path.substr(0, last_sep);
+  return result;
 }
 
 /////////////////////////////////////////////////

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -205,11 +205,11 @@ bool ignition::common::chdir(const std::string &_dir)
 /////////////////////////////////////////////////
 std::string ignition::common::basename(const std::string &_path)
 {
-  fs::path p = fs::path(_path);
+  fs::path p(_path);
   p /= "FOO.TXT";
   p = p.lexically_normal();
   p = p.parent_path();
-  return p.filename().string().empty() ? 
+  return p.filename().string().empty() ?
     std::string{fs::path::preferred_separator} : p.filename().string();
 }
 

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -413,38 +413,47 @@ TEST_F(FilesystemTest, IGN_UTILS_TEST_DISABLED_ON_WIN32(cwd_error))
 }
 
 /////////////////////////////////////////////////
-TEST_F(FilesystemTest, basename)
+TEST_F(FilesystemTest, decomposition)
 {
   std::string absolute = joinPaths("", "home", "bob", "foo");
   EXPECT_EQ(basename(absolute), "foo");
+  EXPECT_EQ(parentPath(absolute), "/home/bob");
 
   std::string relative = joinPaths("baz", "foobar");
   EXPECT_EQ(basename(relative), "foobar");
+  EXPECT_EQ(parentPath(relative), "baz");
 
   std::string bname = "bzzz";
   EXPECT_EQ(basename(bname), "bzzz");
+  EXPECT_EQ(parentPath(bname), "bzzz");
 
   std::string nobase = joinPaths("baz", "");
   EXPECT_EQ(basename(nobase), "baz");
+  EXPECT_EQ(parentPath(nobase), "baz/");
 
   std::string multiple_slash = separator("baz") + separator("") + separator("")
     + separator("");
   EXPECT_EQ(basename(multiple_slash), "baz");
+  EXPECT_EQ(parentPath(multiple_slash), "baz//");
 
   std::string multiple_slash_middle = separator("") + separator("home")
     + separator("") + separator("") + separator("bob") + separator("foo");
   EXPECT_EQ(basename(multiple_slash_middle), "foo");
+  EXPECT_EQ(parentPath(multiple_slash_middle), "/home///bob");
 
   std::string multiple_slash_start = separator("") + separator("")
     + separator("") + separator("home") + separator("bob") + separator("foo");
   EXPECT_EQ(basename(multiple_slash_start), "foo");
+  EXPECT_EQ(parentPath(multiple_slash_start), "///home/bob");
 
   std::string slash_only = separator("") + separator("");
   EXPECT_EQ(basename(slash_only), separator(""));
+  EXPECT_EQ(parentPath(slash_only), "");
 
   std::string multiple_slash_only = separator("") + separator("")
     + separator("") + separator("");
   EXPECT_EQ(basename(multiple_slash_only), separator(""));
+  EXPECT_EQ(parentPath(multiple_slash_only), "//");
 }
 
 /////////////////////////////////////////////////

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -417,7 +417,11 @@ TEST_F(FilesystemTest, decomposition)
 {
   std::string absolute = joinPaths("", "home", "bob", "foo");
   EXPECT_EQ(basename(absolute), "foo");
+#ifndef _WIN32
   EXPECT_EQ(parentPath(absolute), "/home/bob");
+#else
+  EXPECT_EQ(parentPath(absolute), "\\home\\bob");
+#endif
 
   std::string relative = joinPaths("baz", "foobar");
   EXPECT_EQ(basename(relative), "foobar");
@@ -626,7 +630,7 @@ TEST_F(FilesystemTest, separator)
 #ifndef _WIN32
   EXPECT_EQ("/", ignition::common::separator(""));
 #else
-  EXPECT_EQ("\\", ignition::common::separator("")); 
+  EXPECT_EQ("\\", ignition::common::separator(""));
 #endif
 }
 

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -433,22 +433,38 @@ TEST_F(FilesystemTest, decomposition)
 
   std::string nobase = joinPaths("baz", "");
   EXPECT_EQ(basename(nobase), "baz");
+#ifndef _WIN32
   EXPECT_EQ(parentPath(nobase), "baz/");
+#else
+  EXPECT_EQ(parentPath(nobase), "baz");
+#endif
 
   std::string multiple_slash = separator("baz") + separator("") + separator("")
     + separator("");
   EXPECT_EQ(basename(multiple_slash), "baz");
+#ifndef _WIN32
   EXPECT_EQ(parentPath(multiple_slash), "baz//");
+#else
+  EXPECT_EQ(parentPath(multiple_slash), "baz\\\\");
+#endif
 
   std::string multiple_slash_middle = separator("") + separator("home")
     + separator("") + separator("") + separator("bob") + separator("foo");
   EXPECT_EQ(basename(multiple_slash_middle), "foo");
+#ifndef _WIN32
   EXPECT_EQ(parentPath(multiple_slash_middle), "/home///bob");
+#else
+  EXPECT_EQ(parentPath(multiple_slash_middle), "\\home\\\\\\bob");
+#endif
 
   std::string multiple_slash_start = separator("") + separator("")
     + separator("") + separator("home") + separator("bob") + separator("foo");
   EXPECT_EQ(basename(multiple_slash_start), "foo");
+#ifndef _WIN32
   EXPECT_EQ(parentPath(multiple_slash_start), "///home/bob");
+#else
+  EXPECT_EQ(parentPath(multiple_slash_start), "\\\\\\home\\bob");
+#endif
 
   std::string slash_only = separator("") + separator("");
   EXPECT_EQ(basename(slash_only), separator(""));
@@ -457,7 +473,11 @@ TEST_F(FilesystemTest, decomposition)
   std::string multiple_slash_only = separator("") + separator("")
     + separator("") + separator("");
   EXPECT_EQ(basename(multiple_slash_only), separator(""));
+#ifndef _WIN32
   EXPECT_EQ(parentPath(multiple_slash_only), "//");
+#else
+  EXPECT_EQ(parentPath(multiple_slash_only), "\\\\");
+#endif
 }
 
 /////////////////////////////////////////////////

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -436,7 +436,7 @@ TEST_F(FilesystemTest, decomposition)
 #ifndef _WIN32
   EXPECT_EQ(parentPath(nobase), "baz/");
 #else
-  EXPECT_EQ(parentPath(nobase), "baz");
+  EXPECT_EQ(parentPath(nobase), "baz\\");
 #endif
 
   std::string multiple_slash = separator("baz") + separator("") + separator("")

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -621,6 +621,16 @@ TEST_F(FilesystemTest, uniquePaths)
 }
 
 /////////////////////////////////////////////////
+TEST_F(FilesystemTest, separator)
+{
+#ifndef _WIN32
+  EXPECT_EQ("/", ignition::common::separator(""));
+#else
+  EXPECT_EQ("\\", ignition::common::separator("")); 
+#endif
+}
+
+/////////////////////////////////////////////////
 /// Main
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
As it turns out, separator's behavior was not matching the `ign-common5` behavior.  Passing an empty string should return the preferred separator for the operating system.  We were not currently testing for this.