### PR TITLE
Image: make several methods const

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,12 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Common 4.X to 5.X
+
+### Modifications
+
+1. `Image::AvgColor`, `Image::Data` and `Image::RGBData` methods are now `const`.
+
 ## Ignition Common 3.X to 4.X
 
 ### Modifications

--- a/graphics/include/ignition/common/Image.hh
+++ b/graphics/include/ignition/common/Image.hh
@@ -125,13 +125,13 @@ namespace ignition
       /// \brief Get the image as a data array
       /// \param[out] _data Pointer to a NULL array of char.
       /// \param[out] _count The resulting data array size
-      public: void Data(unsigned char **_data, unsigned int &_count);
+      public: void Data(unsigned char **_data, unsigned int &_count) const;
 
       /// \brief Get only the RGB data from the image. This will drop the
       /// alpha channel if one is present.
       /// \param[out] _data Pointer to a NULL array of char.
       /// \param[out] _count The resulting data array size
-      public: void RGBData(unsigned char **_data, unsigned int &_count);
+      public: void RGBData(unsigned char **_data, unsigned int &_count) const;
 
       /// \brief Get the width
       /// \return The image width
@@ -166,7 +166,7 @@ namespace ignition
 
       /// \brief Get the average color
       /// \return The average color
-      public: math::Color AvgColor();
+      public: math::Color AvgColor() const;
 
       /// \brief Get the max color
       /// \return The max color

--- a/graphics/src/Image.cc
+++ b/graphics/src/Image.cc
@@ -61,7 +61,7 @@ namespace ignition
       /// \param[in] _height Height of the image
       /// \return bitmap data with red and blue pixels swapped
       public: FIBITMAP* SwapRedBlue(const unsigned int &_width,
-                                    const unsigned int &_height);
+                                    const unsigned int &_height) const;
     };
   }
 }
@@ -249,7 +249,7 @@ int Image::Pitch() const
 }
 
 //////////////////////////////////////////////////
-void Image::RGBData(unsigned char **_data, unsigned int &_count)
+void Image::RGBData(unsigned char **_data, unsigned int &_count) const
 {
   FIBITMAP *tmp = this->dataPtr->bitmap;
   FIBITMAP *tmp2 = nullptr;
@@ -266,7 +266,7 @@ void Image::RGBData(unsigned char **_data, unsigned int &_count)
 }
 
 //////////////////////////////////////////////////
-void Image::Data(unsigned char **_data, unsigned int &_count)
+void Image::Data(unsigned char **_data, unsigned int &_count) const
 {
   if (this->dataPtr->ShouldSwapRedBlue())
   {
@@ -398,7 +398,7 @@ math::Color Image::Pixel(unsigned int _x, unsigned int _y) const
 }
 
 //////////////////////////////////////////////////
-math::Color Image::AvgColor()
+math::Color Image::AvgColor() const
 {
   unsigned int x, y;
   double rsum, gsum, bsum;
@@ -582,7 +582,7 @@ bool Image::Implementation::CanSwapRedBlue() const
 
 //////////////////////////////////////////////////
 FIBITMAP* Image::Implementation::SwapRedBlue(const unsigned int &_width,
-                                    const unsigned int &_height)
+                                    const unsigned int &_height) const
 {
   FIBITMAP *copy = FreeImage_Copy(this->bitmap, 0, 0, _width, _height);
 


### PR DESCRIPTION
# 🦟 Bug fix

Split out from #292

## Summary

The `Image::Data`, `Image::RGBData`, and `Image::AvgColor` methods do not modify any object data but are not marked as `const`, which prevents other `const` methods from calling them. This changes API, so it must be done on the main branch.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
