### PR TITLE
Adds an `isRelativePath` to determine if path is relative

### DIFF
--- a/include/ignition/common/Filesystem.hh
+++ b/include/ignition/common/Filesystem.hh
@@ -57,6 +57,11 @@ namespace ignition
     /// \return True if _path is a file.
     bool IGNITION_COMMON_VISIBLE isFile(const std::string &_path);
 
+    /// \brief Check if the given path is relative.
+    /// \param[in] _path Path.
+    /// \return True if _path is relative.
+    bool IGNITION_COMMON_VISIBLE isRelativePath(const std::string &_path);
+
     /// \brief Create a new directory on the filesystem.  Intermediate
     ///        directories must already exist.
     /// \param[in] _path  The new directory path to create

--- a/src/Filesystem.cc
+++ b/src/Filesystem.cc
@@ -72,6 +72,12 @@ bool ignition::common::isFile(const std::string &_path)
 }
 
 /////////////////////////////////////////////////
+bool ignition::common::isRelativePath(const std::string &_path)
+{
+  return fs::path(_path).is_relative();
+}
+
+/////////////////////////////////////////////////
 bool ignition::common::createDirectory(const std::string &_path)
 {
   std::error_code ec;

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -245,6 +245,20 @@ TEST_F(FilesystemTest, exists)
   EXPECT_FALSE(isDirectory(absoluteSubdir));
 }
 
+/////////////////////////////////////////////////
+TEST_F(FilesystemTest, relative)
+{
+  #ifndef _WIN32
+    std::string absPath {"/tmp/fstest"};
+    std::string relPath {"../fstest"};
+  #else
+    std::string absPath {"C:\\Users\\user\\Desktop\\test.txt"};
+    std::string relPath {"user\\Desktop\\test.txt"};
+  #endif
+  EXPECT_FALSE(isRelativePath(absPath));
+  EXPECT_TRUE(isRelativePath(relPath));
+}
+
 // The symlink tests require special permissions to work on Windows,
 // so they will be disabled by default. For more information, see:
 // https://github.com/ignitionrobotics/ign-common/issues/21


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This PR adds an `isRelativePath` function to ign-common Filesystem.hh. It is a simple wrapper around `std::filesystem`.  The rationale for this is so we can remove `std::filesystem` from ign-gazebo as this is causing other issues such as https://github.com/ignition-tooling/release-tools/issues/639.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

