### PR TITLE
Minor typo in filesystem documentation

### DIFF
--- a/include/ignition/common/Filesystem.hh
+++ b/include/ignition/common/Filesystem.hh
@@ -241,7 +241,7 @@ namespace ignition
     /// files, by appending numbers to it (i.e. (0), (1), ...)
     /// \param[in] _pathAndName Full absolute path and file name up to the
     /// file extension.
-    /// \param[in] _extension File extension, such as "ddf".
+    /// \param[in] _extension File extension, such as "sdf".
     /// \return Full path with name and extension, which doesn't collide with
     /// existing files
     std::string IGNITION_COMMON_VISIBLE uniqueFilePath(


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

I think `ddf` was suppose to be `sdf`.

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.