### PR TITLE
🧹 Drop all test main functions from gtest files

### DIFF
--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -152,10 +152,3 @@ TEST(AudioDecoder, IGN_UTILS_TEST_DISABLED_ON_WIN32(CheerFile))
                 dataBufferSize == 4987612u * 2);
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/events/src/Event_TEST.cc
+++ b/events/src/Event_TEST.cc
@@ -297,10 +297,3 @@ TEST_F(EventTest, DestructionOrder)
   conn.reset();
   SUCCEED();
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/events/src/MouseEvent_TEST.cc
+++ b/events/src/MouseEvent_TEST.cc
@@ -268,10 +268,3 @@ TEST_F(MouseEvent, Assignment)
   EXPECT_EQ(otherEvent.Alt(), alt);
   EXPECT_EQ(otherEvent.Control(), control);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/geospatial/src/Dem_TEST.cc
+++ b/geospatial/src/Dem_TEST.cc
@@ -213,10 +213,3 @@ TEST_F(DemTest, NonEarthDem)
   ignition::math::Angle latitude, longitude;
   EXPECT_FALSE(dem.GeoReferenceOrigin(latitude, longitude));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/geospatial/src/ImageHeightmap_TEST.cc
+++ b/geospatial/src/ImageHeightmap_TEST.cc
@@ -99,10 +99,3 @@ TEST_F(ImageHeightmapTest, FillHeightmap)
   EXPECT_NEAR(10.0, elevations.at(elevations.size() - 1), ELEVATION_TOL);
   EXPECT_NEAR(5.0, elevations.at(elevations.size() / 2), ELEVATION_TOL);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/Animation_TEST.cc
+++ b/graphics/src/Animation_TEST.cc
@@ -272,10 +272,3 @@ TEST_F(AnimationTest, TrajectoryInfo)
   EXPECT_DOUBLE_EQ(0.0, trajInfo4.DistanceSoFar(2000ms));
   EXPECT_DOUBLE_EQ(0.0, trajInfo4.DistanceSoFar(3000ms));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/ColladaExporter_TEST.cc
+++ b/graphics/src/ColladaExporter_TEST.cc
@@ -443,10 +443,3 @@ TEST_F(ColladaExporter, ExportLights)
   }
   EXPECT_EQ(node_with_light_count, 3);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/ColladaLoader_TEST.cc
+++ b/graphics/src/ColladaLoader_TEST.cc
@@ -487,10 +487,3 @@ TEST_F(ColladaLoader, LoadCylinderAnimatedFrom3dsMax)
   EXPECT_EQ(1u, anim->NodeCount());
   EXPECT_TRUE(anim->HasNode("Bone02"));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/GTSMeshUtils_TEST.cc
+++ b/graphics/src/GTSMeshUtils_TEST.cc
@@ -77,10 +77,3 @@ TEST_F(GTSMeshUtils, DelaunayTriangulation)
   // there should be 8 triangles.
   EXPECT_EQ(subMesh.IndexCount() / 3u, 8u);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/Image_TEST.cc
+++ b/graphics/src/Image_TEST.cc
@@ -561,10 +561,3 @@ INSTANTIATE_TEST_SUITE_P(FlatHeightmaps, ImagePerformanceTest,
     std::make_tuple("heightmap_flat_257x257.png", 257u, 257u),
     std::make_tuple("heightmap_flat_513x513.png", 513u, 513u),
     std::make_tuple("heightmap_flat_1025x1025.png", 1025u, 1025u)));
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/Material_TEST.cc
+++ b/graphics/src/Material_TEST.cc
@@ -97,10 +97,3 @@ TEST_F(MaterialTest, Material)
   EXPECT_NE(nullptr, mat.PbrMaterial());
   EXPECT_EQ(pbr, *mat.PbrMaterial());
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/MeshManager_TEST.cc
+++ b/graphics/src/MeshManager_TEST.cc
@@ -288,11 +288,4 @@ TEST_F(MeshManager, Remove)
   mgr->RemoveAll();
   EXPECT_FALSE(mgr->HasMesh("sphere"));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
 #endif

--- a/graphics/src/Mesh_TEST.cc
+++ b/graphics/src/Mesh_TEST.cc
@@ -151,10 +151,3 @@ TEST_F(MeshTest, Mesh)
   EXPECT_TRUE(math::equal(vertices[2], submesh.lock()->Vertex(0).Z()));
   EXPECT_EQ(indices[0], submesh.lock()->Index(0));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/OBJLoader_TEST.cc
+++ b/graphics/src/OBJLoader_TEST.cc
@@ -131,10 +131,3 @@ TEST_F(OBJLoaderTest, PBR)
     EXPECT_EQ("mesh_Normal.png", pbr->NormalMap());
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/SVGLoader_TEST.cc
+++ b/graphics/src/SVGLoader_TEST.cc
@@ -359,10 +359,3 @@ TEST_F(SVGLoaderTest, MultipleFiles)
     out.close();
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -501,10 +501,3 @@ TEST_F(SubMeshTest, Volume)
   boxSub.AddIndex(1);
   EXPECT_DOUBLE_EQ(0.0, boxSub.Volume());
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Base64_TEST.cc
+++ b/src/Base64_TEST.cc
@@ -49,10 +49,3 @@ TEST_F(Base64, EncodeDecode)
   }
   EXPECT_EQ(original, common::Base64::Decode(encoded));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Battery_TEST.cc
+++ b/src/Battery_TEST.cc
@@ -254,9 +254,3 @@ TEST_F(BatteryTest, SetUpdateFunc)
 
   EXPECT_DOUBLE_EQ(battery->Voltage(), origVolt);
 }
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Console_TEST.cc
+++ b/src/Console_TEST.cc
@@ -539,10 +539,3 @@ TEST_F(Console_TEST, LogDirectory)
 
   EXPECT_EQ(logDir, absPath);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -653,11 +653,3 @@ TEST_F(FilesystemTest, separator)
   EXPECT_EQ("\\", ignition::common::separator(""));
 #endif
 }
-
-/////////////////////////////////////////////////
-/// Main
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/MaterialDensity_TEST.cc
+++ b/src/MaterialDensity_TEST.cc
@@ -67,10 +67,3 @@ TEST_F(MaterialDensityTest, Accessors)
     EXPECT_DOUBLE_EQ(density, 19300);
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/MovingWindowFilter_TEST.cc
+++ b/src/MovingWindowFilter_TEST.cc
@@ -69,9 +69,3 @@ TEST(MovingWindowFilterTest, FilterSomething)
         3.0*static_cast<double>(i));
   EXPECT_EQ(vectorMWF.Value(), vsum / 20.0);
 }
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/PluginLoader_TEST.cc
+++ b/src/PluginLoader_TEST.cc
@@ -73,10 +73,3 @@ TEST(PluginLoader, InstantiateUnloadedPlugin)
       pm.Instantiate("plugin::that::is::not::loaded");
   EXPECT_FALSE(plugin);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/PluginUtils_TEST.cc
+++ b/src/PluginUtils_TEST.cc
@@ -33,11 +33,3 @@ TEST(PluginUtils, NormalizeName)
   EXPECT_EQ("::ignition::math", common::NormalizeName("ignition::math"));
   EXPECT_EQ("::ignition::math", common::NormalizeName("::ignition::math"));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-

--- a/src/StringUtils_TEST.cc
+++ b/src/StringUtils_TEST.cc
@@ -210,11 +210,3 @@ TEST(EndsWith, PluralCast)
   EXPECT_EQ("oxen", common::PluralCast("ox", "oxen", -3));
   EXPECT_EQ("oxen", common::PluralCast("ox", "oxen", -4));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}
-

--- a/src/SystemPaths_TEST.cc
+++ b/src/SystemPaths_TEST.cc
@@ -424,10 +424,3 @@ TEST_F(SystemPathsFixture, PathsFromEnv)
     ++count;
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/TempDirectory_TEST.cc
+++ b/src/TempDirectory_TEST.cc
@@ -110,4 +110,3 @@ TEST(TempDirectory, TempDirectoryNoCleanLater)
   EXPECT_TRUE(ignition::common::exists(path));
   EXPECT_TRUE(ignition::common::removeDirectory(path));
 }
-

--- a/src/TemplateHelpers_TEST.cc
+++ b/src/TemplateHelpers_TEST.cc
@@ -48,9 +48,3 @@ TEST(TemplateHelpers, ConstCompatible)
   EXPECT_TRUE((ConstCompatible<SomeAliasedType, SomeType>::value));
   EXPECT_FALSE((ConstCompatible<SomeType, SomeAliasedType>::value));
 }
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Timer_TEST.cc
+++ b/src/Timer_TEST.cc
@@ -76,10 +76,3 @@ TEST(Timer_TEST, Copy)
   EXPECT_FALSE(t1.Running());
   EXPECT_FALSE(t2.Running());
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/URI_TEST.cc
+++ b/src/URI_TEST.cc
@@ -1006,10 +1006,3 @@ TEST(URITEST, Resource)
     EXPECT_TRUE(uri.Path().IsAbsolute());
   }
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Util_TEST.cc
+++ b/src/Util_TEST.cc
@@ -314,10 +314,3 @@ TEST(Util_TEST, findFile)
   ignition::common::addFindFileURICallback(fileCb);
   EXPECT_EQ(tmpDir, ignition::common::findFile("model://banana"));
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/Uuid_TEST.cc
+++ b/src/Uuid_TEST.cc
@@ -51,10 +51,3 @@ TEST(UuidTest, testToString)
   for (auto i = 24; i < 36; ++i)
     EXPECT_GT(isxdigit(output.str()[i]), 0);
 }
-
-//////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -146,10 +146,3 @@ TEST(WorkerPool,
   }
   EXPECT_EQ(2, sentinel);
 }
-
-//////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/integration/mesh.cc
+++ b/test/integration/mesh.cc
@@ -296,10 +296,3 @@ TEST_F(MeshTest, SubMeshCenter)
   EXPECT_EQ(ignition::math::Vector3d(5.46554, 2.18039, 4.8431), mesh->Max());
   EXPECT_EQ(ignition::math::Vector3d(3.46555, 0.180391, 2.8431), mesh->Min());
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/integration/plugin.cc
+++ b/test/integration/plugin.cc
@@ -435,10 +435,3 @@ TEST(PluginPtr, QueryInterfaceSharedPtr)
   SetSomeValues(setter);
   CheckSomeValues(getInt, getDouble, getName);
 }
-
-/////////////////////////////////////////////////
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/test/integration/video_encoder.cc
+++ b/test/integration/video_encoder.cc
@@ -138,4 +138,3 @@ TEST_F(EncoderDecoderTest, DecodeEncodeDecode)
 
   delete[] buf;
 }
-

--- a/test/performance/plugin_specialization.cc
+++ b/test/performance/plugin_specialization.cc
@@ -228,10 +228,3 @@ TEST(PluginSpecialization, AccessTime)
               << "ns\n" << std::endl;
   }
 }
-
-
-int main(int argc, char **argv)
-{
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}


### PR DESCRIPTION
All of our tests link `gtest_main`, so including main functions is redundant.

Signed-off-by: Michael Carroll <michael@openrobotics.org>