### PR TITLE
Class with final destructor should be final

### DIFF
--- a/profiler/src/RemoteryProfilerImpl.hh
+++ b/profiler/src/RemoteryProfilerImpl.hh
@@ -44,7 +44,7 @@ namespace ignition
     /// * RMT_QUEUE_SIZE: Size of the internal message queues
     /// * RMT_MSGS_PER_UPDATE: Upper limit on messages consumed per loop
     /// * RMT_SLEEP_BETWEEN_UPDATES: Controls profile server update rate.
-    class RemoteryProfilerImpl: public ProfilerImpl
+    class RemoteryProfilerImpl final: public ProfilerImpl
     {
       /// \brief Constructor.
       public: RemoteryProfilerImpl();


### PR DESCRIPTION
Cleans up a clang12 warning.

```
In file included from /home/mjcarroll/workspaces/ign_garden/src/ign-common/profiler/src/RemoteryProfilerImpl.cc:20:
/home/mjcarroll/workspaces/ign_garden/src/ign-common/profiler/src/RemoteryProfilerImpl.hh:53:39: warning: class with destructor marked 'final' cannot be inherited from [-Wfinal-dtor-non-final-class]
      public: ~RemoteryProfilerImpl() final;
                                      ^
/home/mjcarroll/workspaces/ign_garden/src/ign-common/profiler/src/RemoteryProfilerImpl.hh:47:11: note: mark 'ignition::common::RemoteryProfilerImpl' as 'final' to silence this warning
    class RemoteryProfilerImpl: public ProfilerImpl
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>