### PR TITLE
Fix compatibility with FFmpeg 5.0

### DIFF
--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -128,8 +128,10 @@ TEST(AudioDecoder, IGN_UTILS_TEST_DISABLED_ON_WIN32(CheerFile))
     audio.Decode(&dataBuffer, &dataBufferSize);
     // In Ubuntu trusty the buffer size double for ogg decoding.
     // This check is suitable for both older and newer versions of Ubuntu.
+    // With ffmpeg 5.0 the value changed again (third value)
     EXPECT_TRUE(dataBufferSize == 4989184u ||
-                dataBufferSize == 4989184u * 2u);
+                dataBufferSize == 4989184u * 2u ||
+                dataBufferSize == 9975224u);
   }
 
   // MP3

--- a/av/src/Video.cc
+++ b/av/src/Video.cc
@@ -91,7 +91,7 @@ void Video::Cleanup()
 /////////////////////////////////////////////////
 bool Video::Load(const std::string &_filename)
 {
-  AVCodec *codec = nullptr;
+  const AVCodec * codec = nullptr;
   this->dataPtr->videoStream = -1;
 
   if (this->dataPtr->formatCtx || this->dataPtr->avFrame ||

--- a/av/src/VideoEncoder.cc
+++ b/av/src/VideoEncoder.cc
@@ -106,7 +106,7 @@ class IGNITION_COMMON_AV_HIDDEN ignition::common::VideoEncoderPrivate
   /// Find a suitable encoder for the given codec ID.
   /// \param[in] _codecId ID of the codec we seek the encoder for.
   /// \return The matched encoder (or nullptr on failure).
-  public: AVCodec* FindEncoder(AVCodecID _codecId);
+  public: const AVCodec* FindEncoder(AVCodecID _codecId);
 
   /// \brief Get a pointer to the frame that contains the encoder input. This
   /// mainly serves for uploading the frame to GPU buffer if HW acceleration is
@@ -123,7 +123,7 @@ class IGNITION_COMMON_AV_HIDDEN ignition::common::VideoEncoderPrivate
 };
 
 /////////////////////////////////////////////////
-AVCodec* VideoEncoderPrivate::FindEncoder(AVCodecID _codecId)
+const AVCodec* VideoEncoderPrivate::FindEncoder(AVCodecID _codecId)
 {
 #ifdef IGN_COMMON_BUILD_HW_VIDEO
   if (this->hwEncoder)
@@ -367,7 +367,7 @@ bool VideoEncoder::Start(
   }
   else
   {
-    AVOutputFormat *outputFormat = av_guess_format(nullptr,
+    const AVOutputFormat *outputFormat = av_guess_format(nullptr,
                                    this->dataPtr->filename.c_str(), nullptr);
 
     if (!outputFormat)


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #306

## Summary

This PR fixes compilation against FFmpeg 5.0 . It has been tested by using the conda-forge build of ffmpeg 5.0 on Linux, in particular with this deps:
~~~
# packages in environment at /home/traversaro/mambaforge/envs/igncommondev:
#
# Name                    Version                   Build  Channel
_libgcc_mutex             0.1                 conda_forge    conda-forge
_openmp_mutex             4.5                       1_gnu    conda-forge
aom                       3.3.0                h27087fc_1    conda-forge
binutils                  2.36.1               hdd6e379_2    conda-forge
binutils_impl_linux-64    2.36.1               h193b22a_2    conda-forge
binutils_linux-64         2.36                 hf3e587d_8    conda-forge
bzip2                     1.0.8                h7f98852_4    conda-forge
c-ares                    1.18.1               h7f98852_0    conda-forge
c-compiler                1.4.1                h166bdaf_0    conda-forge
ca-certificates           2021.10.8            ha878542_0    conda-forge
cmake                     3.22.3               h5432695_0    conda-forge
compilers                 1.4.1                ha770c72_0    conda-forge
cxx-compiler              1.4.1                h924138e_0    conda-forge
eigen                     3.4.0                h4bd325d_0    conda-forge
expat                     2.4.7                h27087fc_0    conda-forge
ffmpeg                    5.0.0                h594f047_1    conda-forge
fortran-compiler          1.4.1                h2a4ca65_0    conda-forge
freeimage                 3.18.0               h88c329d_7    conda-forge
freetype                  2.10.4               h0708190_1    conda-forge
gcc                       10.3.0               he2824d0_8    conda-forge
gcc_impl_linux-64         10.3.0              hf2f2afa_14    conda-forge
gcc_linux-64              10.3.0               hc39de41_8    conda-forge
gettext                   0.19.8.1          h73d1719_1008    conda-forge
gfortran                  10.3.0               h18518b4_8    conda-forge
gfortran_impl_linux-64    10.3.0              h73f4979_14    conda-forge
gfortran_linux-64         10.3.0               hb09a455_8    conda-forge
glib                      2.70.2               h780b84a_4    conda-forge
glib-tools                2.70.2               h780b84a_4    conda-forge
gmp                       6.2.1                h58526e2_0    conda-forge
gnutls                    3.6.13               h85f3911_1    conda-forge
gts                       0.7.6                h64030ff_2    conda-forge
gxx                       10.3.0               he2824d0_8    conda-forge
gxx_impl_linux-64         10.3.0              hf2f2afa_14    conda-forge
gxx_linux-64              10.3.0               h2593f52_8    conda-forge
icu                       69.1                 h9c3ff4c_0    conda-forge
ilmbase                   2.5.5                h780b84a_0    conda-forge
jbig                      2.1               h7f98852_2003    conda-forge
jpeg                      9e                   h7f98852_0    conda-forge
jxrlib                    1.1                  h7f98852_2    conda-forge
kernel-headers_linux-64   2.6.32              he073ed8_15    conda-forge
keyutils                  1.6.1                h166bdaf_0    conda-forge
krb5                      1.19.3               h08a2579_0    conda-forge
lame                      3.100             h7f98852_1001    conda-forge
lcms2                     2.12                 hddcbb42_0    conda-forge
ld_impl_linux-64          2.36.1               hea4e1c9_2    conda-forge
lerc                      3.0                  h9c3ff4c_0    conda-forge
libcurl                   7.82.0               h2283fc2_0    conda-forge
libdeflate                1.10                 h7f98852_0    conda-forge
libdrm                    2.4.109              h7f98852_0    conda-forge
libedit                   3.1.20191231         he28a2e2_2    conda-forge
libev                     4.33                 h516909a_1    conda-forge
libffi                    3.4.2                h7f98852_5    conda-forge
libgcc-devel_linux-64     10.3.0              he6cfe16_14    conda-forge
libgcc-ng                 11.2.0              h1d223b6_14    conda-forge
libgfortran5              11.2.0              h5c6108e_14    conda-forge
libglib                   2.70.2               h174f98d_4    conda-forge
libgomp                   11.2.0              h1d223b6_14    conda-forge
libiconv                  1.16                 h516909a_0    conda-forge
libignition-cmake2        2.11.0               h27087fc_0    conda-forge
libignition-math6         6.10.0               h9c3ff4c_0    conda-forge
libnghttp2                1.47.0               he49606f_0    conda-forge
libnsl                    2.0.0                h7f98852_0    conda-forge
libpciaccess              0.16                 h516909a_0    conda-forge
libpng                    1.6.37               h21135ba_2    conda-forge
libraw                    0.20.2               h10796ff_1    conda-forge
libsanitizer              10.3.0              h26c7422_14    conda-forge
libssh2                   1.10.0               ha35d2d1_2    conda-forge
libstdcxx-devel_linux-64  10.3.0              he6cfe16_14    conda-forge
libstdcxx-ng              11.2.0              he4da1e4_14    conda-forge
libtiff                   4.3.0                h542a066_3    conda-forge
libuuid                   2.32.1            h7f98852_1000    conda-forge
libuv                     1.43.0               h7f98852_0    conda-forge
libva                     2.14.0               h7f98852_0    conda-forge
libvpx                    1.11.0               h9c3ff4c_3    conda-forge
libwebp-base              1.2.2                h7f98852_1    conda-forge
libxcb                    1.13              h7f98852_1004    conda-forge
libxml2                   2.9.12               h885dcf4_1    conda-forge
libzlib                   1.2.11            h36c2ea0_1013    conda-forge
lz4-c                     1.9.3                h9c3ff4c_1    conda-forge
ncurses                   6.3                  h9c3ff4c_0    conda-forge
nettle                    3.6                  he412f7d_0    conda-forge
ninja                     1.10.2               h4bd325d_1    conda-forge
openexr                   2.5.5                hf817b99_0    conda-forge
openh264                  2.1.1                h780b84a_0    conda-forge
openjpeg                  2.4.0                hb52868f_1    conda-forge
openssl                   3.0.0                h7f98852_2    conda-forge
pcre                      8.45                 h9c3ff4c_0    conda-forge
pip                       22.0.4             pyhd8ed1ab_0    conda-forge
pkg-config                0.29.2            h36c2ea0_1008    conda-forge
pthread-stubs             0.4               h36c2ea0_1001    conda-forge
python                    3.10.2          hc74c709_4_cpython    conda-forge
python_abi                3.10                    2_cp310    conda-forge
readline                  8.1                  h46c0cb4_0    conda-forge
rhash                     1.4.1                h7f98852_0    conda-forge
setuptools                60.10.0         py310hff52083_0    conda-forge
sqlite                    3.37.1               h4ff8645_0    conda-forge
svt-av1                   0.9.1                h27087fc_0    conda-forge
sysroot_linux-64          2.12                he073ed8_15    conda-forge
tinyxml2                  9.0.0                h9c3ff4c_2    conda-forge
tk                        8.6.12               h27826a3_0    conda-forge
tzdata                    2022a                h191b570_0    conda-forge
wheel                     0.37.1             pyhd8ed1ab_0    conda-forge
x264                      1!161.3030           h7f98852_1    conda-forge
x265                      3.5                  h924138e_3    conda-forge
xorg-fixesproto           5.0               h7f98852_1002    conda-forge
xorg-kbproto              1.0.7             h7f98852_1002    conda-forge
xorg-libx11               1.7.2                h7f98852_0    conda-forge
xorg-libxau               1.0.9                h7f98852_0    conda-forge
xorg-libxdmcp             1.1.3                h7f98852_0    conda-forge
xorg-libxext              1.3.4                h7f98852_1    conda-forge
xorg-libxfixes            5.0.3             h7f98852_1004    conda-forge
xorg-xextproto            7.3.0             h7f98852_1002    conda-forge
xorg-xproto               7.0.31            h7f98852_1007    conda-forge
xz                        5.2.5                h516909a_1    conda-forge
zlib                      1.2.11            h36c2ea0_1013    conda-forge
zstd                      1.5.2                ha95c52a_0    conda-forge
~~~

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
