### PR TITLE
Fix issue 331

### DIFF
--- a/src/Console.cc
+++ b/src/Console.cc
@@ -86,7 +86,7 @@ Logger::~Logger()
 /////////////////////////////////////////////////
 Logger &Logger::operator()()
 {
-  Console::log << "(" << ignition::common::systemTimeIso() << ") ";
+  Console::log() << "(" << ignition::common::systemTimeIso() << ") ";
   (*this) << Console::Prefix() << this->prefix;
 
   return (*this);
@@ -97,7 +97,7 @@ Logger &Logger::operator()(const std::string &_file, int _line)
 {
   int index = _file.find_last_of("/") + 1;
 
-  Console::log << "(" << ignition::common::systemTimeIso() << ") ";
+  Console::log() << "(" << ignition::common::systemTimeIso() << ") ";
   std::stringstream prefixString;
   prefixString << Console::Prefix() << this->prefix
     << "[" << _file.substr(index , _file.size() - index) << ":"

--- a/test/integration/console.cc
+++ b/test/integration/console.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+#include "ignition/common/Console.hh"
+#include "test_config.h"
+
+using namespace ignition;
+
+TEST(Console_TEST, LogInitAfterConsoleOut)
+{
+  std::string logFilename = "uri.log";
+  std::string logDir = common::joinPaths(PROJECT_BINARY_PATH, "test", "uri");
+  std::string logFile = common::joinPaths(logDir, logFilename);
+
+  common::Console::SetVerbosity(4);
+
+  // We are not logging to a file yet.
+  ignerr << "This is an error" << std::endl;
+
+  // Initialize the log file.
+  ignLogInit(logDir, logFilename);
+
+  // Run the same console output, which should output the message to the log
+  // file.
+  ignerr << "This is an error" << std::endl;
+  std::ifstream t(logFile);
+  std::string buffer((std::istreambuf_iterator<char>(t)),
+                 std::istreambuf_iterator<char>());
+
+  EXPECT_TRUE(buffer.find("This is an error") != std::string::npos)
+    << "Log file content[" << buffer << "]\n";
+}


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

Fixes #331 

## Summary

Use `Console:log()` in Console.cc in order to support execution of the `ignLogInit` function after console out has occured.

## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.