### PR TITLE
Fix typo bug in MaterialIndex

### DIFF
--- a/graphics/src/SubMesh.cc
+++ b/graphics/src/SubMesh.cc
@@ -496,10 +496,8 @@ void SubMesh::SetMaterialIndex(const unsigned int _index)
 //////////////////////////////////////////////////
 unsigned int SubMesh::MaterialIndex() const
 {
-  if (this-dataPtr->materialIndex.has_value())
-    return this->dataPtr->materialIndex.value();
-
-  return std::numeric_limits<unsigned int>::max();
+  return this->dataPtr->materialIndex.value_or(
+      std::numeric_limits<unsigned int>::max());
 }
 
 //////////////////////////////////////////////////

--- a/graphics/src/SubMesh_TEST.cc
+++ b/graphics/src/SubMesh_TEST.cc
@@ -39,6 +39,22 @@ TEST_F(SubMeshTest, SubMesh)
   submesh->SetPrimitiveType(common::SubMesh::TRIANGLES);
   EXPECT_EQ(submesh->SubMeshPrimitiveType(), common::SubMesh::TRIANGLES);
 
+  {
+    // Test deprecated API
+    // TODO(azeey) Remove this scope block when MaterialIndex is removed
+    IGN_UTILS_WARN_IGNORE__DEPRECATED_DECLARATION
+    EXPECT_EQ(submesh->MaterialIndex(),
+              std::numeric_limits<unsigned int>::max());
+    submesh->SetMaterialIndex(3u);
+    EXPECT_EQ(submesh->MaterialIndex(), 3u);
+    // Recreate submesh to so test expectations following this block won't
+    // break.
+    submesh = std::make_shared<common::SubMesh>();
+    ASSERT_NE(nullptr, submesh);
+    IGN_UTILS_WARN_RESUME__DEPRECATED_DECLARATION
+  }
+
+  // Use new API
   EXPECT_FALSE(submesh->GetMaterialIndex().has_value());
   submesh->SetMaterialIndex(3u);
   ASSERT_TRUE(submesh->GetMaterialIndex().has_value());


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
A typo in the following snippet was causing `materialIndex` to be accessed when did not contain a value.
```c++
if (this-dataPtr->materialIndex.has_value()) //  Note the `-` instead of `->` in `this-dataPtr`.
    return this->dataPtr->materialIndex.value();
```


## Checklist
- [x] Signed all commits for DCO
- [x] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

