### PR TITLE
Use ign-utils instead of ign-cmake utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(ignition-common5 VERSION 5.0.0)
 #============================================================================
 # Find ignition-cmake
 #============================================================================
-find_package(ignition-cmake2 2.8.0 REQUIRED COMPONENTS utilities)
+find_package(ignition-cmake2 2.8.0 REQUIRED)
 set(IGN_CMAKE_VER ${ignition-cmake2_VERSION_MAJOR})
 
 #============================================================================

--- a/av/src/AudioDecoder_TEST.cc
+++ b/av/src/AudioDecoder_TEST.cc
@@ -17,7 +17,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/AudioDecoder.hh>
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include "test_config.h"
 

--- a/av/src/CMakeLists.txt
+++ b/av/src/CMakeLists.txt
@@ -24,6 +24,5 @@ endif()
 ign_build_tests(TYPE UNIT SOURCES ${gtest_sources}
   LIB_DEPS
     ${av_target}
-    ignition-cmake${IGN_CMAKE_VER}::utilities
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,8 +15,8 @@ else()
 endif()
 
 # Link the libraries that we always need
-target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME} 
-  PRIVATE 
+target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
+  PRIVATE
     ${DL_TARGET}
     ${CXX_FILESYSTEM_LIBRARIES}
   PUBLIC
@@ -48,8 +48,6 @@ endif()
 ign_build_tests(
   TYPE UNIT
   SOURCES ${gtest_sources}
-  LIB_DEPS
-    ignition-cmake${IGN_CMAKE_VER}::utilities
   INCLUDE_DIRS
     # Used to make internal source file headers visible to the unit tests
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/Filesystem_TEST.cc
+++ b/src/Filesystem_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 #include <ignition/common/Console.hh>
 #include <ignition/common/Filesystem.hh>

--- a/src/TempDirectory_TEST.cc
+++ b/src/TempDirectory_TEST.cc
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 
 #include <ignition/common/TempDirectory.hh>
-#include <ignition/utilities/ExtraTestMacros.hh>
+#include <ignition/utils/ExtraTestMacros.hh>
 
 /////////////////////////////////////////////////
 TEST(TempDirectory, tempDirectoryPath)

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <gtest/gtest.h>
+#include <gtest/gtest.h> 
 
 #include <atomic>
 

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -21,7 +21,7 @@
 
 #include "ignition/common/Console.hh"
 #include "ignition/common/WorkerPool.hh"
-#include "ignition/utilities/ExtraTestMacros.hh"
+#include "ignition/utils/ExtraTestMacros.hh"
 
 namespace igncmn = ignition::common;
 using namespace igncmn;

--- a/src/WorkerPool_TEST.cc
+++ b/src/WorkerPool_TEST.cc
@@ -15,7 +15,7 @@
  *
 */
 
-#include <gtest/gtest.h> 
+#include <gtest/gtest.h>
 
 #include <atomic>
 


### PR DESCRIPTION
# 🎉 New feature

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

`ign-cmake` utilities are deprecated from Garden. We should use `ign-utils` instead.

This should help with 

* https://github.com/ignition-tooling/release-tools/issues/685

## Test it
<!--Explain how reviewers can test this new feature manually.-->

CI should pass.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
