### PR TITLE
fix switch case fall through warning

### DIFF
--- a/graphics/src/SVGLoader.cc
+++ b/graphics/src/SVGLoader.cc
@@ -597,6 +597,7 @@ ignition::math::Vector2d SVGLoader::Implementation::SubpathToPolyline(
           _last = pEnd;
           i += 7;
         }
+        break;
       // Z and z indicate closed path.
       // just add the first point to the list
       case 'Z':


### PR DESCRIPTION
<!-- 
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://ignitionrobotics.org/docs/all/contributing
-->

# 🦟 Bug fix

## Bug

Warning is raised when compiling on Ubuntu Jammy using g++11.

```
/home/ijnek/ignition/garden/src/ign-common/graphics/src/SVGLoader.cc:584:18: warning: this statement may fall through [-Wimplicit-fallthrough=]
  584 |         while (i < count)
      |                ~~^~~~~~~
/home/ijnek/ignition/garden/src/ign-common/graphics/src/SVGLoader.cc:602:7: note: here
  602 |       case 'Z':
      |       ^~~~
---
```

## Summary
Simply add a break to the switch case statement as the fallthrough seems unintended.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
